### PR TITLE
Rename repo references: unicorn-depthcache-cluster-for-binance → unicorn-binance-depth-cache-cluster

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,10 +4,10 @@ contact_links:
     url: https://t.me/unicorndevs
     about: Chat with the community about the UNICORN Binance DepthCache Cluster and ask general questions.
   - name: UNICORN Binance DepthCache Cluster Discussions
-    url: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/discussions
+    url: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/discussions
     about: Ask general questions.
   - name: UNICORN Binance DepthCache Cluster documentation
-    url: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/
+    url: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/
     about: The complete UNICORN Binance DepthCache Cluster documentation.
   - name: Get Professional and Fast Support
     url: https://about.me/oliver-zehentleitner/get-support.html

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
 Contributions via GitHub pull requests are welcome. However, contributors should be aware that submitted code
 automatically becomes LUCIT IT-Management GmbH's property and copyright.
 
-Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE) 
+Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE) 
 thoroughly!
 
 # PR Details
@@ -44,13 +44,13 @@ thoroughly!
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
 - [ ] I understand that the exploitation right of my donated code is transferred to the LUCIT company according to the 
-[MIT license](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE) 
+[MIT license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE) 
 agreement. This is important so that we can publish your code in our packages.
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.
 - [ ] I have read the 
-**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md)** 
+**[CONTRIBUTING](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md)** 
 document.
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.

--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -19,7 +19,7 @@ jobs:
         tag_name: 0.1.4
         name: Release 0.1.4
         body: |
-          Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/changelog.html) for further information.
+          Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/changelog.html) for further information.
         draft: false
         prerelease: false
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
-# unicorn-depthcache-cluster-for-binance Change Log
+# unicorn-binance-depth-cache-cluster Change Log
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to 
 [Semantic Versioning](http://semver.org/).
 
-[Discussions about unicorn-depthcache-cluster-for-binance releases!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/discussions/categories/releases)
+[Discussions about unicorn-binance-depth-cache-cluster releases!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/discussions/categories/releases)
 
-[How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/readme.html#installation-and-upgrade)
+[How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.2.0
 ### Added
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 0.1.4
 ### Fixed
-- https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues/8 - We don't overwrite 
+- https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues/8 - We don't overwrite 
   the None anymore.
 
 ## 0.1.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,15 +3,15 @@
 Contributions via GitHub pull requests are welcome. However, contributors should be aware that submitted code
 automatically becomes Oliver Zehentleitner's property and copyright.
 
-Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE) 
+Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE) 
 thoroughly!
 
 When contributing to this repository, please first discuss the change you wish to make via 
-[issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues/new/choose) 
+[issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues/new/choose) 
 with the owners of this repository before making a change. 
 
 Please note we have a 
-[code of conduct](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CODE_OF_CONDUCT.md), 
+[code of conduct](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CODE_OF_CONDUCT.md), 
 please follow it in all your interactions with the project.
 
 ## Pull Request Process

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
-[![Build and Publish PyPi (ubdcc-dcn)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_dcn.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_dcn.yml)
-[![Build and Publish PyPi (ubdcc-mgmt)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml)
-[![Build and Publish PyPi (ubdcc-restapi)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_restapi.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_restapi.yml)
-[![Build and Publish PyPi (ubdcc-shared-modules)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_shared_modules.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_shared_modules.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
+[![Build and Publish PyPi (ubdcc-dcn)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_dcn.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_dcn.yml)
+[![Build and Publish PyPi (ubdcc-mgmt)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml)
+[![Build and Publish PyPi (ubdcc-restapi)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_restapi.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_restapi.yml)
+[![Build and Publish PyPi (ubdcc-shared-modules)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_shared_modules.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_shared_modules.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
 
 # UNICORN DepthCache Cluster for Binance (UBDCC)
@@ -20,8 +20,8 @@ JSON format.
 [Get help](https://about.me/oliver-zehentleitner/get-support.html)!
 
 If you like the project, please 
-[![star](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/master/images/misc/star.png)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/stargazers) it on 
-[GitHub](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)! 
+[![star](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/master/images/misc/star.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/stargazers) it on 
+[GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)! 
 
 ## What is UBDCC?
 
@@ -68,11 +68,11 @@ provided by
 
 The first MVP is stable and offers the most critical features for efficient DepthCache management. Future improvements 
 might include switching to websockets instead of REST queries, or implementing simultaneous queries for both Asks and 
-Bids. [Vote here for new features!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+Bids. [Vote here for new features!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 
 For more information, check out the 
-[GitHub Repository](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) and the
-[Docs](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance).
+[GitHub Repository](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) and the
+[Docs](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster).
 
 ## Watch a Demo Video
 [![Watch the demo video](https://img.youtube.com/vi/hq2iZPiFnvE/maxresdefault.jpg)](https://www.youtube.com/watch?v=hq2iZPiFnvE)
@@ -91,7 +91,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/late
 - Prepare `helm`
 
 ``` 
-helm repo add ubdcc https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/helm
+helm repo add ubdcc https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/helm
 helm repo update
 ```
 
@@ -131,7 +131,7 @@ helm install ubdcc ubdcc/ubdcc --set publicPort.restapi=8080
 ```
   
 ### Kubernetes Deployment
-- [Download the deployment files](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/tree/master/admin/k8s)
+- [Download the deployment files](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/admin/k8s)
 - Apply the deployment files with `kubectl`
 
 ``` 
@@ -183,28 +183,28 @@ kubectl delete -f ./ubdcc-restapi_service.yaml
 
 ## Accessing the DepthCaches
 
-The UNICORN DepthCache Cluster for Binance is accessed with the Python module [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache?tab=readme-ov-file#connect-to-a-unicorn-depthcache-cluster-for-binance).
+The UNICORN DepthCache Cluster for Binance is accessed with the Python module [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache?tab=readme-ov-file#connect-to-a-unicorn-binance-depth-cache-cluster).
 
-Just try this [examples](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/tree/master/examples/unicorn_depthcache_cluster_for_binance)!
+Just try this [examples](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/tree/master/examples/unicorn_binance_depth_cache_cluster)!
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN DepthCache Cluster for Binance](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN DepthCache Cluster for Binance](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
 We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/heart.png) open source!
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,14 +1,14 @@
 # Security Policies and Procedures
 This document outlines security procedures and general policies for the 
-`unicorn-depthcache-cluster-for-binance` project.
+`unicorn-binance-depth-cache-cluster` project.
 
   * [Reporting a Bug](#reporting-a-bug)
   * [Disclosure Policy](#disclosure-policy)
   * [Comments on this Policy](#comments-on-this-policy)
 
 ## Reporting a Bug
-`Oliver Zehentleitner` takes all security bugs in `unicorn-depthcache-cluster-for-binance` seriously.
-Thank you for improving the security of `unicorn-depthcache-cluster-for-binance`. We appreciate your 
+`Oliver Zehentleitner` takes all security bugs in `unicorn-binance-depth-cache-cluster` seriously.
+Thank you for improving the security of `unicorn-binance-depth-cache-cluster`. We appreciate your 
 efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
 Report security bugs via our contact form: 

--- a/container/dev_station/README.md
+++ b/container/dev_station/README.md
@@ -1,26 +1,26 @@
 # ***IN DEVELOPMENT!!!***
 
-[![Get a UNICORN DepthCache Cluster for Binance License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/logo/LUCIT-UBDCC-License-Offer.png)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![Get a UNICORN DepthCache Cluster for Binance License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-License-Offer.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 
-[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![PyPi Release](https://img.shields.io/pypi/v/unicorn-depthcache-cluster-for-binance?color=blue)](https://pypi.org/project/unicorn-depthcache-cluster-for-binance/)
-[![PyPi Downloads](https://pepy.tech/badge/unicorn-depthcache-cluster-for-binance)](https://pepy.tech/project/unicorn-depthcache-cluster-for-binance)
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
+[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-depth-cache-cluster?color=blue)](https://pypi.org/project/unicorn-binance-depth-cache-cluster/)
+[![PyPi Downloads](https://pepy.tech/badge/unicorn-binance-depth-cache-cluster)](https://pepy.tech/project/unicorn-binance-depth-cache-cluster)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_depthcache_cluster.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/unicorn_binance_depthcache_cluster.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)
-[![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
-[![CodeQL](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/codeql-analysis.yml)
-[![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/unit-tests.yml)
-[![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels.yml)
-[![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_conda.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![PyPI - Status](https://img.shields.io/pypi/status/unicorn_binance_depthcache_cluster.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)
+[![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
+[![CodeQL](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/codeql-analysis.yml)
+[![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/unit-tests.yml)
+[![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels.yml)
+[![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_conda.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
 
-[![LUCIT-UBDCC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/logo/LUCIT-UBDCC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![LUCIT-UBDCC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 
 # UNICORN Binance DepthCache Cluster - UBDCC Dev Station (Docker Image)
 
@@ -36,25 +36,25 @@
 
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
-We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/misc/heart.png) open source!
+We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/misc/heart.png) open source!
 
 ## Disclaimer
 This project is for informational purposes only. You should not construe this information or any other material as 

--- a/container/generic_loader/README.md
+++ b/container/generic_loader/README.md
@@ -1,26 +1,26 @@
 # ***IN DEVELOPMENT!!!***
 
-[![Get a UNICORN DepthCache Cluster for Binance License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/logo/LUCIT-UBDCC-License-Offer.png)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![Get a UNICORN DepthCache Cluster for Binance License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-License-Offer.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 
-[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![PyPi Release](https://img.shields.io/pypi/v/unicorn-depthcache-cluster-for-binance?color=blue)](https://pypi.org/project/unicorn-depthcache-cluster-for-binance/)
-[![PyPi Downloads](https://pepy.tech/badge/unicorn-depthcache-cluster-for-binance)](https://pepy.tech/project/unicorn-depthcache-cluster-for-binance)
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
+[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-depth-cache-cluster?color=blue)](https://pypi.org/project/unicorn-binance-depth-cache-cluster/)
+[![PyPi Downloads](https://pepy.tech/badge/unicorn-binance-depth-cache-cluster)](https://pepy.tech/project/unicorn-binance-depth-cache-cluster)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/unicorn_binance_depthcache_cluster.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/unicorn_binance_depthcache_cluster.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)
-[![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
-[![CodeQL](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/codeql-analysis.yml)
-[![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/unit-tests.yml)
-[![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels.yml)
-[![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_conda.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![PyPI - Status](https://img.shields.io/pypi/status/unicorn_binance_depthcache_cluster.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)
+[![codecov](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/branch/master/graph/badge.svg?token=5I03AZ3F5S)](https://codecov.io/gh/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
+[![CodeQL](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/codeql-analysis.yml)
+[![Unit Tests](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/unit-tests.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/unit-tests.yml)
+[![Build and Publish GH+PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels.yml)
+[![Build and Publish Anaconda](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_conda.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_conda.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
 
-[![LUCIT-UBDCC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/logo/LUCIT-UBDCC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![LUCIT-UBDCC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 
 # UNICORN Binance DepthCache Cluster - UBDCC Generic Loader (Docker Image)
 
@@ -36,25 +36,25 @@
 
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
-We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/master/images/misc/heart.png) open source!
+We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/misc/heart.png) open source!
 
 ## Disclaimer
 This project is for informational purposes only. You should not construe this information or any other material as 

--- a/container/generic_loader/start_ubdcc_dcn.py
+++ b/container/generic_loader/start_ubdcc_dcn.py
@@ -4,14 +4,14 @@
 #
 # File: packages/ubdcc-dcn/start_ubdcc_dcn.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
-# PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 # LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/container/generic_loader/start_ubdcc_mgmt.py
+++ b/container/generic_loader/start_ubdcc_mgmt.py
@@ -4,14 +4,14 @@
 #
 # File: container/generic_loader/start_ubdcc_mgmt.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
-# PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 # LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/container/generic_loader/start_ubdcc_restapi.py
+++ b/container/generic_loader/start_ubdcc_restapi.py
@@ -4,14 +4,14 @@
 #
 # File: container/generic_loader/start_ubdcc_dcn.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
-# PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 # LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -1,13 +1,13 @@
-# unicorn-depthcache-cluster-for-binance Change Log
+# unicorn-binance-depth-cache-cluster Change Log
 
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to 
 [Semantic Versioning](http://semver.org/).
 
-[Discussions about unicorn-depthcache-cluster-for-binance releases!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/discussions/categories/releases)
+[Discussions about unicorn-binance-depth-cache-cluster releases!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/discussions/categories/releases)
 
-[How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/readme.html#installation-and-upgrade)
+[How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.2.0
 ### Added
@@ -32,7 +32,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 0.1.4
 ### Fixed
-- https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues/8 - We don't overwrite 
+- https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues/8 - We don't overwrite 
   the None anymore.
 
 ## 0.1.3

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -24,7 +24,7 @@ sys.path.insert(0, os.path.abspath('../../../packages/ubdcc-shared-modules/'))
 
 # -- Project information -----------------------------------------------------
 
-project = 'unicorn-depthcache-cluster-for-binance'
+project = 'unicorn-binance-depth-cache-cluster'
 copyright = '2024-2026, Oliver Zehentleitner'
 author = 'Oliver Zehentleitner'
 
@@ -89,7 +89,7 @@ pygments_style = None
 
 html_theme = 'alabaster'
 html_context = {'github_user_name': 'oliver-zehentleitner',
-                'github_repo_name': 'unicorn-depthcache-cluster-for-binance',
+                'github_repo_name': 'unicorn-binance-depth-cache-cluster',
                 'project_name': project,
 
 myst_heading_anchors = 3
@@ -118,7 +118,7 @@ html_static_path = ['_static']
 # -- Options for HTMLHelp output ---------------------------------------------
 
 # Output file base name for HTML help builder.
-htmlhelp_basename = 'unicorn-depthcache-cluster-for-binance-apidoc'
+htmlhelp_basename = 'unicorn-binance-depth-cache-cluster-apidoc'
 
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -145,8 +145,8 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'unicorn-depthcache-cluster-for-binance.tex',
-     'unicorn-depthcache-cluster-for-binance Documentation',
+    (master_doc, 'unicorn-binance-depth-cache-cluster.tex',
+     'unicorn-binance-depth-cache-cluster Documentation',
      'Oliver Zehentleitner', 'manual'),
 ]
 
@@ -156,7 +156,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'unicorn-depthcache-cluster-for-binance', 'unicorn-depthcache-cluster-for-binance Documentation',
+    (master_doc, 'unicorn-binance-depth-cache-cluster', 'unicorn-binance-depth-cache-cluster Documentation',
      [author], 1)
 ]
 
@@ -167,8 +167,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'unicorn-depthcache-cluster-for-binance', 'unicorn-depthcache-cluster-for-binance Documentation',
-     author, 'unicorn-depthcache-cluster-for-binance', 'One line description of project.',
+    (master_doc, 'unicorn-binance-depth-cache-cluster', 'unicorn-binance-depth-cache-cluster Documentation',
+     author, 'unicorn-binance-depth-cache-cluster', 'One line description of project.',
      'Miscellaneous'),
 ]
 

--- a/dev/sphinx/source/contributing.md
+++ b/dev/sphinx/source/contributing.md
@@ -3,15 +3,15 @@
 Contributions via GitHub pull requests are welcome. However, contributors should be aware that submitted code
 automatically becomes Oliver Zehentleitner's property and copyright.
 
-Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE) 
+Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE) 
 thoroughly!
 
 When contributing to this repository, please first discuss the change you wish to make via 
-[issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues/new/choose) 
+[issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues/new/choose) 
 with the owners of this repository before making a change. 
 
 Please note we have a 
-[code of conduct](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CODE_OF_CONDUCT.md), 
+[code of conduct](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CODE_OF_CONDUCT.md), 
 please follow it in all your interactions with the project.
 
 ## Pull Request Process

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -1,12 +1,12 @@
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
-[![Build and Publish PyPi (ubdcc-dcn)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_dcn.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_dcn.yml)
-[![Build and Publish PyPi (ubdcc-mgmt)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml)
-[![Build and Publish PyPi (ubdcc-restapi)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_restapi.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_restapi.yml)
-[![Build and Publish PyPi (ubdcc-shared-modules)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_shared_modules.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_shared_modules.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
+[![Build and Publish PyPi (ubdcc-dcn)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_dcn.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_dcn.yml)
+[![Build and Publish PyPi (ubdcc-mgmt)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml)
+[![Build and Publish PyPi (ubdcc-restapi)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_restapi.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_restapi.yml)
+[![Build and Publish PyPi (ubdcc-shared-modules)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_shared_modules.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_shared_modules.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 
 # UNICORN DepthCache Cluster for Binance (UBDCC)
@@ -20,15 +20,15 @@ JSON format.
 [Get help](https://about.me/oliver-zehentleitner/get-support.html)!
 
 If you like the project, please 
-[![star](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/master/images/misc/star.png)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/stargazers) it on 
-[GitHub](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)! 
+[![star](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/master/images/misc/star.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/stargazers) it on 
+[GitHub](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)! 
 
 ## Get a UNICORN DepthCache Cluster for Binance License
 
 ***Licenses will only be publicly available in the store in a few days. If you are interested in a free trial license, 
 please [contact us via the chat](https://about.me/oliver-zehentleitner/get-support.html)!***
 
-To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)!
+To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)!
 
 ## What is UBDCC?
 
@@ -75,11 +75,11 @@ provided by
 
 The first MVP is stable and offers the most critical features for efficient DepthCache management. Future improvements 
 might include switching to websockets instead of REST queries, or implementing simultaneous queries for both Asks and 
-Bids. [Vote here for new features!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
+Bids. [Vote here for new features!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement)
 
 For more information, check out the 
-[GitHub Repository](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) and the
-[Docs](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance).
+[GitHub Repository](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) and the
+[Docs](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster).
 
 ## Watch a Demo Video
 [![Watch the demo video](https://img.youtube.com/vi/hq2iZPiFnvE/maxresdefault.jpg)](https://www.youtube.com/watch?v=hq2iZPiFnvE)
@@ -98,7 +98,7 @@ kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/late
 - Prepare `helm`
 
 ``` 
-helm repo add ubdcc https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/helm
+helm repo add ubdcc https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/helm
 helm repo update
 ```
 
@@ -138,7 +138,7 @@ helm install ubdcc ubdcc/ubdcc --set publicPort.restapi=8080
 ```
   
 ### Kubernetes Deployment
-- [Download the deployment files](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/tree/master/admin/k8s)
+- [Download the deployment files](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/admin/k8s)
 - Apply the deployment files with `kubectl`
 
 ``` 
@@ -190,28 +190,28 @@ kubectl delete -f ./ubdcc-restapi_service.yaml
 
 ## Accessing the DepthCaches
 
-The UNICORN DepthCache Cluster for Binance is accessed with the Python module [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache?tab=readme-ov-file#connect-to-a-unicorn-depthcache-cluster-for-binance).
+The UNICORN DepthCache Cluster for Binance is accessed with the Python module [UNICORN Binance Local Depth Cache](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache?tab=readme-ov-file#connect-to-a-unicorn-binance-depth-cache-cluster).
 
-Just try this [examples](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/tree/master/examples/unicorn_depthcache_cluster_for_binance)!
+Just try this [examples](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/tree/master/examples/unicorn_binance_depth_cache_cluster)!
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN DepthCache Cluster for Binance](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN DepthCache Cluster for Binance](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
 We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/heart.png) open source!
 

--- a/dev/sphinx/source/security.md
+++ b/dev/sphinx/source/security.md
@@ -1,14 +1,14 @@
 # Security Policies and Procedures
 This document outlines security procedures and general policies for the 
-`unicorn-depthcache-cluster-for-binance` project.
+`unicorn-binance-depth-cache-cluster` project.
 
   * [Reporting a Bug](#reporting-a-bug)
   * [Disclosure Policy](#disclosure-policy)
   * [Comments on this Policy](#comments-on-this-policy)
 
 ## Reporting a Bug
-`Oliver Zehentleitner` takes all security bugs in `unicorn-depthcache-cluster-for-binance` seriously.
-Thank you for improving the security of `unicorn-depthcache-cluster-for-binance`. We appreciate your 
+`Oliver Zehentleitner` takes all security bugs in `unicorn-binance-depth-cache-cluster` seriously.
+Thank you for improving the security of `unicorn-binance-depth-cache-cluster`. We appreciate your 
 efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
 Report security bugs via our contact form: 

--- a/packages/ubdcc-dcn/README.md
+++ b/packages/ubdcc-dcn/README.md
@@ -1,13 +1,13 @@
-[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
+[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/ubdcc-mgmt?color=blue)](https://pypi.org/project/ubdcc-mgmt/)
 [![PyPi Downloads](https://pepy.tech/badge/ubdcc-mgmt)](https://pepy.tech/project/ubdcc-mgmt)
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/ubdcc-mgmt.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-mgmt.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)
-[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/tree/master/packages/ubdcc-mgmt)
+[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-mgmt.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)
+[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/packages/ubdcc-mgmt)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
@@ -15,30 +15,30 @@
 # UNICORN Binance DepthCache Cluster DepthCacheNode
 The `ubdcc-dcn` module for UNICORN Binance DepthCache Cluster DepthCacheNode.
 
-Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)'.
+Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)'.
 
 ## Get a UNICORN DepthCache Cluster for Binance License
 
-To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)!
+To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)!
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead 
 links to new features. To contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
 We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/heart.png) open source!
 

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -5,20 +5,20 @@ description = "UBDCC Depth Cache Node — manages local Binance order books in a
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-documentation = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-repository = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
+homepage = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+documentation = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
 
 [tool.poetry.urls]
-'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto'
-'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance'
-'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki'
+'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto'
+'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster'
+'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki'
 'Author' = 'https://about.me/oliver-zehentleitner'
-'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-dcn/CHANGELOG.md'
-'License' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE'
-'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues'
+'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-dcn/CHANGELOG.md'
+'License' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE'
+'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues'
 'Telegram' = 'https://t.me/unicorndevs'
-'Chat' = 'https://app.gitter.im/#/room/#unicorn-depthcache-cluster-for-binance:gitter.im'
+'Chat' = 'https://app.gitter.im/#/room/#unicorn-binance-depth-cache-cluster:gitter.im'
 'Get Support' = 'https://about.me/oliver-zehentleitner/get-support.html'
 
 [tool.poetry.dependencies]

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -4,13 +4,13 @@
 # File: packages/ubdcc-dcn/setup.py
 #
 # Part of ‘UNICORN Binance DepthCache Cluster’
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-dcn
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
@@ -33,7 +33,7 @@ setup(
     version="0.2.0",
     author="Oliver Zehentleitner",
     author_email='',
-    url="https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance",
+    url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
     description="UBDCC Depth Cache Node — manages local Binance order books in a cluster pod",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -42,14 +42,14 @@ setup(
                       'unicorn-binance-local-depth-cache>=2.8.1'],
     keywords='',
     project_urls={
-        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto',
-        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance',
-        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki',
+        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',
+        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster',
+        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki',
         'Author': 'https://about.me/oliver-zehentleitner',
-        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-dcn/CHANGELOG.md',
-        'License': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE',
-        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues',
-        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance',
+        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-dcn/CHANGELOG.md',
+        'License': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE',
+        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues',
+        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster',
         'Telegram': 'https://t.me/unicorndevs',
         'Get Support': 'https://about.me/oliver-zehentleitner/get-support.html',
     },

--- a/packages/ubdcc-dcn/start_ubdcc_dcn.py
+++ b/packages/ubdcc-dcn/start_ubdcc_dcn.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-dcn/start_ubdcc_dcn.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
-# PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-dcn
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-dcn
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-mgmt/README.md
+++ b/packages/ubdcc-mgmt/README.md
@@ -1,13 +1,13 @@
-[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
+[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/ubdcc-mgmt?color=blue)](https://pypi.org/project/ubdcc-mgmt/)
 [![PyPi Downloads](https://pepy.tech/badge/ubdcc-mgmt)](https://pepy.tech/project/ubdcc-mgmt)
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/ubdcc-mgmt.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-mgmt.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)
-[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/tree/master/packages/ubdcc-mgmt)
+[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-mgmt.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)
+[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/packages/ubdcc-mgmt)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
@@ -15,30 +15,30 @@
 # UNICORN Binance DepthCache Cluster Management
 The `ubdcc-mgmt` module for UNICORN Binance DepthCache Cluster Management.
 
-Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)'.
+Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)'.
 
 ## Get a UNICORN DepthCache Cluster for Binance License
 
-To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)!
+To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)!
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
 We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/heart.png) open source!
 

--- a/packages/ubdcc-mgmt/pyproject.toml
+++ b/packages/ubdcc-mgmt/pyproject.toml
@@ -5,20 +5,20 @@ description = "UBDCC Mgmt — orchestration and node registry for the UNICORN De
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-documentation = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-repository = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
+homepage = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+documentation = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
 
 [tool.poetry.urls]
-'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto'
-'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance'
-'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki'
+'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto'
+'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster'
+'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki'
 'Author' = 'https://about.me/oliver-zehentleitner'
-'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-mgmt/CHANGELOG.md'
-'License' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE'
-'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues'
+'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-mgmt/CHANGELOG.md'
+'License' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE'
+'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues'
 'Telegram' = 'https://t.me/unicorndevs'
-'Chat' = 'https://app.gitter.im/#/room/#unicorn-depthcache-cluster-for-binance:gitter.im'
+'Chat' = 'https://app.gitter.im/#/room/#unicorn-binance-depth-cache-cluster:gitter.im'
 'Get Support' = 'https://about.me/oliver-zehentleitner/get-support.html'
 
 [tool.poetry.dependencies]

--- a/packages/ubdcc-mgmt/setup.py
+++ b/packages/ubdcc-mgmt/setup.py
@@ -4,13 +4,13 @@
 # File: packages/ubdcc-mgmt/setup.py
 #
 # Part of ‘UNICORN Binance DepthCache Cluster’
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-mgmt
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
@@ -33,7 +33,7 @@ setup(
     version="0.2.0",
     author="Oliver Zehentleitner",
     author_email='',
-    url="https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance",
+    url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
     description="UBDCC Management Service — orchestrates the UNICORN DepthCache Cluster for Binance",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -41,14 +41,14 @@ setup(
     install_requires=['ubdcc-shared-modules==0.2.0'],
     keywords='',
     project_urls={
-        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto',
-        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance',
-        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki',
+        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',
+        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster',
+        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki',
         'Author': 'https://about.me/oliver-zehentleitner',
-        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-mgmt/CHANGELOG.md',
-        'License': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE',
-        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues',
-        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance',
+        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-mgmt/CHANGELOG.md',
+        'License': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE',
+        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues',
+        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster',
         'Telegram': 'https://t.me/unicorndevs',
         'Get Support': 'https://about.me/oliver-zehentleitner/get-support.html',
     },

--- a/packages/ubdcc-mgmt/start_ubdcc_mgmt.py
+++ b/packages/ubdcc-mgmt/start_ubdcc_mgmt.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-mgmt/start_ubdcc_mgmt.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
-# PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-mgmt
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-mgmt
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-restapi/README.md
+++ b/packages/ubdcc-restapi/README.md
@@ -1,44 +1,44 @@
-[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
+[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/ubdcc-mgmt?color=blue)](https://pypi.org/project/ubdcc-mgmt/)
 [![PyPi Downloads](https://pepy.tech/badge/ubdcc-mgmt)](https://pepy.tech/project/ubdcc-mgmt)
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/ubdcc-mgmt.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-mgmt.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)
-[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_mgmt.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/tree/master/packages/ubdcc-mgmt)
+[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-mgmt.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)
+[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_mgmt.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/packages/ubdcc-mgmt)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-depthcache-cluster-for-binance?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
 
 # UNICORN Binance DepthCache Cluster REST API
 The `ubdcc-restapi` module for UNICORN Binance DepthCache Cluster REST API.
 
-Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)'.
+Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)'.
 
 ## Get a UNICORN DepthCache Cluster for Binance License
 
-To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)!
+To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)!
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
 We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/heart.png) open source!
 

--- a/packages/ubdcc-restapi/pyproject.toml
+++ b/packages/ubdcc-restapi/pyproject.toml
@@ -5,20 +5,20 @@ description = "UBDCC REST API — public HTTP API for the UNICORN DepthCache Clu
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-documentation = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-repository = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
+homepage = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+documentation = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
 
 [tool.poetry.urls]
-'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto'
-'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance'
-'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki'
+'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto'
+'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster'
+'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki'
 'Author' = 'https://about.me/oliver-zehentleitner'
-'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-restapi/CHANGELOG.md'
-'License' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE'
-'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues'
+'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-restapi/CHANGELOG.md'
+'License' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE'
+'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues'
 'Telegram' = 'https://t.me/unicorndevs'
-'Chat' = 'https://app.gitter.im/#/room/#unicorn-depthcache-cluster-for-binance:gitter.im'
+'Chat' = 'https://app.gitter.im/#/room/#unicorn-binance-depth-cache-cluster:gitter.im'
 'Get Support' = 'https://about.me/oliver-zehentleitner/get-support.html'
 
 [tool.poetry.dependencies]

--- a/packages/ubdcc-restapi/setup.py
+++ b/packages/ubdcc-restapi/setup.py
@@ -4,13 +4,13 @@
 # File: packages/ubdcc-restapi/setup.py
 #
 # Part of ‘UNICORN Binance DepthCache Cluster’
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-restapi
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
@@ -33,7 +33,7 @@ setup(
     version="0.2.0",
     author="Oliver Zehentleitner",
     author_email='',
-    url="https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance",
+    url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
     description="UBDCC REST API — public REST interface for the UNICORN DepthCache Cluster for Binance",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -41,14 +41,14 @@ setup(
     install_requires=['ubdcc-shared-modules==0.2.0'],
     keywords='',
     project_urls={
-        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto',
-        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance',
-        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki',
+        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',
+        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster',
+        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki',
         'Author': 'https://about.me/oliver-zehentleitner',
-        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-restapi/CHANGELOG.md',
-        'License': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE',
-        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues',
-        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance',
+        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-restapi/CHANGELOG.md',
+        'License': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE',
+        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues',
+        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster',
         'Telegram': 'https://t.me/unicorndevs',
         'Get Support': 'https://about.me/oliver-zehentleitner/get-support.html',
     },

--- a/packages/ubdcc-restapi/start_ubdcc_restapi.py
+++ b/packages/ubdcc-restapi/start_ubdcc_restapi.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-restapi/start_ubdcc_restapi.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
-# PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-restapi
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-restapi
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-shared-modules/README.md
+++ b/packages/ubdcc-shared-modules/README.md
@@ -1,13 +1,13 @@
-[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
-[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/releases)
+[![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
+[![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/ubdcc-shared-modules?color=blue)](https://pypi.org/project/ubdcc-shared-modules/)
 [![PyPi Downloads](https://pepy.tech/badge/ubdcc-shared-modules)](https://pepy.tech/project/ubdcc-shared-modules)
-[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/license.html)
+[![License](https://img.shields.io/badge/license-MIT-blue)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/license.html)
 [![Supported Python Version](https://img.shields.io/pypi/pyversions/ubdcc-shared-modules.svg)](https://www.python.org/downloads/)
-[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-shared-modules.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)
-[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_shared_modules.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/actions/workflows/build_wheels_ubdcc_shared_modules.yml)
-[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance)
-[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/tree/master/packages/ubdcc-shared-modules)
+[![PyPI - Status](https://img.shields.io/pypi/status/ubdcc-shared-modules.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)
+[![Build and Publish PyPi](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_shared_modules.yml/badge.svg)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/actions/workflows/build_wheels_ubdcc_shared_modules.yml)
+[![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
+[![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/packages/ubdcc-shared-modules)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Get Free Professional Support](
@@ -15,30 +15,30 @@
 # UNICORN Binance DepthCache Cluster Shared Modules
 The general `ubdcc-shared-modules` module for the K8 Pods of the UNICORN Binance DepthCache Cluster.
 
-Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)'.
+Part of '[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)'.
 
 ## Get a UNICORN DepthCache Cluster for Binance License
 
-To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance)!
+To run the *UNICORN DepthCache Cluster for Binance* you need a [valid license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)!
 
 ## How to report Bugs or suggest Improvements?
-[List of planned features](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
+[List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
 
-Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
+Before you report a bug, [try the latest release](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#installation-and-upgrade). If the issue still exists, provide the error trace, OS 
 and Python version and explain how to reproduce the error. A demo script is appreciated.
 
-If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues)!
+If you don't find an issue related to your topic, please open a new [issue](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues)!
 
-[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/security/policy)
+[Report a security bug!](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/policy)
 
 ## Contributing
-[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) is an open 
+[UNICORN Binance DepthCache Cluster](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster) is an open 
 source project which welcomes contributions which can be anything from simple documentation fixes and reporting dead links to new features. To 
 contribute follow 
-[this guide](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/CONTRIBUTING.md).
+[this guide](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CONTRIBUTING.md).
  
 ### Contributors
-[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/graphs/contributors)
+[![Contributors](https://contributors-img.web.app/image?repo=oliver-zehentleitner/unicorn-binance-depth-cache-cluster)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/graphs/contributors)
 
 We ![love](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/misc/heart.png) open source!
 

--- a/packages/ubdcc-shared-modules/pyproject.toml
+++ b/packages/ubdcc-shared-modules/pyproject.toml
@@ -5,20 +5,20 @@ description = "UBDCC Shared Modules — core library for all UBDCC services"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"
-homepage = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-documentation = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
-repository = "https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance"
+homepage = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+documentation = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
+repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster"
 
 [tool.poetry.urls]
-'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto'
-'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance'
-'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki'
+'Howto' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto'
+'Documentation' = 'https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster'
+'Wiki' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki'
 'Author' = 'https://about.me/oliver-zehentleitner'
-'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-mgmt/CHANGELOG.md'
-'License' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE'
-'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues'
+'Changes' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-mgmt/CHANGELOG.md'
+'License' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE'
+'Issue Tracker' = 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues'
 'Telegram' = 'https://t.me/unicorndevs'
-'Chat' = 'https://app.gitter.im/#/room/#unicorn-depthcache-cluster-for-binance:gitter.im'
+'Chat' = 'https://app.gitter.im/#/room/#unicorn-binance-depth-cache-cluster:gitter.im'
 'Get Support' = 'https://about.me/oliver-zehentleitner/get-support.html'
 
 [tool.poetry.dependencies]

--- a/packages/ubdcc-shared-modules/setup.py
+++ b/packages/ubdcc-shared-modules/setup.py
@@ -4,13 +4,13 @@
 # File: packages/ubdcc-shared-modules/setup.py
 #
 # Part of ‘UNICORN Binance DepthCache Cluster’
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-shared-modules/
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
@@ -33,7 +33,7 @@ setup(
     version="0.2.0",
     author="Oliver Zehentleitner",
     author_email='',
-    url="https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance",
+    url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
     description="UBDCC Shared Modules — core library for the UNICORN DepthCache Cluster for Binance",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -41,14 +41,14 @@ setup(
     install_requires=['aiohttp', 'Cython', 'fastapi', 'kubernetes', 'uvicorn'],
     keywords='',
     project_urls={
-        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance#howto',
-        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance',
-        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/wiki',
+        'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',
+        'Documentation': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster',
+        'Wiki': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/wiki',
         'Author': 'https://about.me/oliver-zehentleitner',
-        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/packages/ubdcc-mgmt/CHANGELOG.md',
-        'License': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE',
-        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/issues',
-        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-depthcache-cluster-for-binance',
+        'Changes': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/packages/ubdcc-mgmt/CHANGELOG.md',
+        'License': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE',
+        'Issue Tracker': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues',
+        'Chat': 'https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster',
         'Telegram': 'https://t.me/unicorndevs',
         'Get Support': 'https://about.me/oliver-zehentleitner/get-support.html',
     },

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-shared-modules
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-mgmt/ubdcc_mgmt/Database.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-shared-modules
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-shared-modules
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestServer.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestServer.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-shared-modules/ubdcc_shared_modules/RestServer.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-shared-modules
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
@@ -4,13 +4,13 @@
 #
 # File: packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
 #
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/ubdcc-shared-modules
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #


### PR DESCRIPTION
Update all internal references (URLs, docstrings, Sphinx config, CHANGELOGs, READMEs) to match the new GitHub repository name.