### PR TITLE
Replace json with orjson for faster JSON parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
+## 0.2.1 (development)
+### Changed
+- Replaced `json` with `orjson` for faster JSON parsing (closes #5)
+
 ## 0.2.0
 ### Added
 - AGENTS.md and TASKS.md

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -18,7 +18,7 @@
 # All rights reserved.
 
 import base64
-import json
+import orjson as json
 from ubdcc_shared_modules.Database import Database
 from ubdcc_shared_modules.RestEndpointsBase import RestEndpointsBase, Request
 

--- a/packages/ubdcc-shared-modules/pyproject.toml
+++ b/packages/ubdcc-shared-modules/pyproject.toml
@@ -25,6 +25,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 python = ">=3.12.0"
 aiohttp = "*"
 Cython = "*"
+orjson = "*"
 fastapi = "*"
 kubernetes = "*"
 uvicorn = "*"

--- a/packages/ubdcc-shared-modules/requirements.txt
+++ b/packages/ubdcc-shared-modules/requirements.txt
@@ -1,5 +1,6 @@
 aiohttp
 cython
 fastapi
+orjson
 kubernetes
 uvicorn

--- a/packages/ubdcc-shared-modules/setup.py
+++ b/packages/ubdcc-shared-modules/setup.py
@@ -38,7 +38,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',
-    install_requires=['aiohttp', 'Cython', 'fastapi', 'kubernetes', 'uvicorn'],
+    install_requires=['aiohttp', 'Cython', 'fastapi', 'kubernetes', 'orjson', 'uvicorn'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -21,7 +21,7 @@ import aiohttp
 import asyncio
 import cython
 import logging
-import json
+import orjson as json
 import os
 import signal as sys_signal
 import socket

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
@@ -17,7 +17,7 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
-import json
+import orjson as json
 import time
 from fastapi import Request
 from fastapi.responses import JSONResponse


### PR DESCRIPTION
Closes #5

## Changes
- Add `orjson` dependency to `ubdcc-shared-modules` (pyproject.toml, setup.py, requirements.txt)
- Replace `import json` with `import orjson as json` in App.py, RestEndpointsBase.py, RestEndpoints.py
- All call sites use `json.loads()` only — fully compatible with orjson's API