### PR TITLE
Fix URL-too-long on /create_depthcaches by switching to POST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 0.2.1 (development)
 ### Changed
 - Replaced `json` with `orjson` for faster JSON parsing (closes #5)
+- `/create_depthcaches` switched from GET to POST — markets list is now sent as JSON body, fixing URL-too-long errors when creating many DepthCaches at once (closes #10)
 
 ## 0.2.0
 ### Added

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -17,7 +17,6 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
-import base64
 import orjson as json
 from ubdcc_shared_modules.Database import Database
 from ubdcc_shared_modules.RestEndpointsBase import RestEndpointsBase, Request
@@ -35,7 +34,7 @@ class RestEndpoints(RestEndpointsBase):
         async def create_depthcache(request: Request):
             return await self.create_depthcache(request=request)
 
-        @self.fastapi.get("/create_depthcaches")
+        @self.fastapi.post("/create_depthcaches")
         async def create_depthcaches(request: Request):
             return await self.create_depthcaches(request=request)
 
@@ -125,11 +124,12 @@ class RestEndpoints(RestEndpointsBase):
         ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
         if ready_check is not None:
             return ready_check
-        exchange = request.query_params.get("exchange", None)
-        markets = request.query_params.get("markets", None)
-        desired_quantity = request.query_params.get("desired_quantity", None)
-        update_interval = request.query_params.get("update_interval", None)
-        refresh_interval = request.query_params.get("refresh_interval", None)
+        body = json.loads(await request.body())
+        exchange = body.get("exchange", None)
+        markets = body.get("markets", None)
+        desired_quantity = body.get("desired_quantity", None)
+        update_interval = body.get("update_interval", None)
+        refresh_interval = body.get("refresh_interval", None)
         if exchange == "None":
             exchange = None
         if markets == "None":
@@ -149,7 +149,6 @@ class RestEndpoints(RestEndpointsBase):
         if exchange is None or markets is None:
             return self.get_error_response(event=event, error_id="#1016",
                                            message="Missing required parameter: exchange, markets")
-        markets = json.loads(base64.b64decode(markets).decode('utf-8'))
         for market in markets:
             if self.db.exists_depthcache(exchange=exchange, market=market) is False:
                 try:

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -32,7 +32,7 @@ class RestEndpoints(RestEndpointsBase):
         async def create_depthcache(request: Request):
             return await self.create_depthcache(request=request)
 
-        @self.fastapi.get("/create_depthcaches")
+        @self.fastapi.post("/create_depthcaches")
         async def create_depthcaches(request: Request):
             return await self.create_depthcaches(request=request)
 
@@ -152,18 +152,9 @@ class RestEndpoints(RestEndpointsBase):
         request_url = str(request.url)
         used_pods: list = [[self.app.id['name'], self.app.id['uid']]]
         host = self.app.get_cluster_mgmt_address()
-        exchange = request.query_params.get("exchange")
-        markets = request.query_params.get("markets")
-        desired_quantity = request.query_params.get("desired_quantity")
-        update_interval = request.query_params.get("update_interval")
-        refresh_interval = request.query_params.get("refresh_interval")
-        query = (f"?exchange={exchange}&"
-                 f"markets={markets}&"
-                 f"update_interval={update_interval}&"
-                 f"refresh_interval={refresh_interval}&"
-                 f"desired_quantity={desired_quantity}")
-        url = host + endpoint + query
-        result = await self.app.request(url=url, method="get")
+        body = await request.json()
+        url = host + endpoint
+        result = await self.app.request(url=url, method="post", params=body)
         if result.get('error') is not None and result.get('error_id') is not None:
             return self.get_error_response(event=event, error_id="#9000", message=f"Mgmt service not available!",
                                            params={"error": str(result)}, process_start_time=process_start_time,


### PR DESCRIPTION
Closes #10

## Problem
`/create_depthcaches` used a GET request with markets as a base64-encoded query parameter. With many markets the URL exceeded the server limit.

## Fix
- Switch `/create_depthcaches` from GET to POST in both mgmt and restapi
- mgmt reads `exchange`, `markets`, `desired_quantity`, `update_interval`, `refresh_interval` from the JSON request body
- restapi forwards the body as-is via POST to mgmt (no more base64 encoding needed)
- Remove now-unused `base64` import from mgmt RestEndpoints