### PR TITLE
Update build runners from ubuntu-20.04 to ubuntu-22.04

### DIFF
--- a/.github/workflows/build_wheels_ubdcc_dcn.yml
+++ b/.github/workflows/build_wheels_ubdcc_dcn.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_wheels:
     name: Build Linux wheels for Python 3.12
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CIBW_BUILD: "cp312-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"

--- a/.github/workflows/build_wheels_ubdcc_mgmt.yml
+++ b/.github/workflows/build_wheels_ubdcc_mgmt.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_wheels:
     name: Build Linux wheels for Python 3.12
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CIBW_BUILD: "cp312-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"

--- a/.github/workflows/build_wheels_ubdcc_restapi.yml
+++ b/.github/workflows/build_wheels_ubdcc_restapi.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_wheels:
     name: Build Linux wheels for Python 3.12
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CIBW_BUILD: "cp312-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"

--- a/.github/workflows/build_wheels_ubdcc_shared_modules.yml
+++ b/.github/workflows/build_wheels_ubdcc_shared_modules.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build_wheels:
     name: Build Linux wheels for Python 3.12
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       CIBW_BUILD: "cp312-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"


### PR DESCRIPTION
ubuntu-20.04 runners were retired by GitHub in April 2025. Updated all 4 build workflows to ubuntu-22.04.