### PR TITLE
Build wheels for Python 3.12, 3.13 and 3.14, fix Cython syntax error

### DIFF
--- a/.github/workflows/build_wheels_ubdcc_dcn.yml
+++ b/.github/workflows/build_wheels_ubdcc_dcn.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12
+    name: Build Linux wheels for Python 3.12, 3.13, 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-*"
+      CIBW_BUILD: "cp312-* cp313-* cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,9 +28,10 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12)
-        uses: pypa/cibuildwheel@v2.16.5
+      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+        uses: pypa/cibuildwheel@v2.22.0
         env:
+          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_ubdcc_mgmt.yml
+++ b/.github/workflows/build_wheels_ubdcc_mgmt.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12
+    name: Build Linux wheels for Python 3.12, 3.13, 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-*"
+      CIBW_BUILD: "cp312-* cp313-* cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,9 +28,10 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12)
-        uses: pypa/cibuildwheel@v2.16.5
+      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+        uses: pypa/cibuildwheel@v2.22.0
         env:
+          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_ubdcc_restapi.yml
+++ b/.github/workflows/build_wheels_ubdcc_restapi.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12
+    name: Build Linux wheels for Python 3.12, 3.13, 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-*"
+      CIBW_BUILD: "cp312-* cp313-* cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,9 +28,10 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12)
-        uses: pypa/cibuildwheel@v2.16.5
+      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+        uses: pypa/cibuildwheel@v2.22.0
         env:
+          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_ubdcc_shared_modules.yml
+++ b/.github/workflows/build_wheels_ubdcc_shared_modules.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12
+    name: Build Linux wheels for Python 3.12, 3.13, 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-*"
+      CIBW_BUILD: "cp312-* cp313-* cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -29,9 +29,10 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12)
-        uses: pypa/cibuildwheel@v2.16.5
+      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+        uses: pypa/cibuildwheel@v2.22.0
         env:
+          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -552,6 +552,3 @@ class App:
                                 log="error")
             await asyncio.sleep(3)
         return False
-        except AttributeError as error_msg:
-            self.stdout_msg(f"Invalid license! - AttributeError: {error_msg}", log="error")
-            return False


### PR DESCRIPTION
- Update cibuildwheel `v2.16.5` → `v2.22.0`
- Add `cp313-*` and `cp314-*` to build matrix
- Enable `CIBW_PRERELEASE_PYTHONS: true` for 3.14 support
- Fix Cython build error: remove orphaned `except AttributeError` block in `App.py` left over from LUCIT licensing removal