### PR TITLE
Build for Python 3.12 and 3.13 only, remove 3.14

### DIFF
--- a/.github/workflows/build_wheels_ubdcc_dcn.yml
+++ b/.github/workflows/build_wheels_ubdcc_dcn.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.12, 3.13
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp312-* cp313-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,10 +28,9 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.12, 3.13)
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_ubdcc_mgmt.yml
+++ b/.github/workflows/build_wheels_ubdcc_mgmt.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.12, 3.13
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp312-* cp313-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,10 +28,9 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.12, 3.13)
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_ubdcc_restapi.yml
+++ b/.github/workflows/build_wheels_ubdcc_restapi.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.12, 3.13
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp312-* cp313-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,10 +28,9 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.12, 3.13)
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheels_ubdcc_shared_modules.yml
+++ b/.github/workflows/build_wheels_ubdcc_shared_modules.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.12, 3.13
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp312-* cp313-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -29,10 +29,9 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.12, 3.13)
         uses: pypa/cibuildwheel@v2.22.0
         env:
-          CIBW_PRERELEASE_PYTHONS: "true"
           CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Unit test
       run: pytest --cov --cov-branch --cov-report=xml unittest_ubdcc.py -v
 
-  test_python_3_14:
+  test_python_3_13:
     runs-on: ubuntu-latest
     steps:
     - name: GitHub Checkout
@@ -34,7 +34,7 @@ jobs:
 
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.14"
+        python-version: "3.13"
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
## Summary
- Remove Python 3.14 from all 4 cibuildwheel build workflows (CIBW_BUILD, CIBW_PRERELEASE_PYTHONS)
- Change unit test job from Python 3.14 to 3.13
- Only build stable Python 3.12 and 3.13