### PR TITLE
Switch to Python 3.14 only, drop 3.12 and 3.13

### DIFF
--- a/.github/workflows/build_wheels_ubdcc_dcn.yml
+++ b/.github/workflows/build_wheels_ubdcc_dcn.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,7 +28,7 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.14)
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PRERELEASE_PYTHONS: "true"

--- a/.github/workflows/build_wheels_ubdcc_mgmt.yml
+++ b/.github/workflows/build_wheels_ubdcc_mgmt.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,7 +28,7 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.14)
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PRERELEASE_PYTHONS: "true"

--- a/.github/workflows/build_wheels_ubdcc_restapi.yml
+++ b/.github/workflows/build_wheels_ubdcc_restapi.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -28,7 +28,7 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.14)
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PRERELEASE_PYTHONS: "true"

--- a/.github/workflows/build_wheels_ubdcc_shared_modules.yml
+++ b/.github/workflows/build_wheels_ubdcc_shared_modules.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build_wheels:
-    name: Build Linux wheels for Python 3.12, 3.13, 3.14
+    name: Build Linux wheels for Python 3.14
     runs-on: ubuntu-22.04
     env:
-      CIBW_BUILD: "cp312-* cp313-* cp314-*"
+      CIBW_BUILD: "cp314-*"
       CIBW_SKIP: "cp36-* cp37-* cp38-* cp39-* cp310-* cp311-* pp36-* pp37-* pp38-* pp39-* pp310-* pp311-*"
     steps:
       - name: Checkout specific directory
@@ -29,7 +29,7 @@ jobs:
       - name: ls -l
         run: ls -l
 
-      - name: Build wheels for Linux (Python 3.12, 3.13, 3.14)
+      - name: Build wheels for Linux (Python 3.14)
         uses: pypa/cibuildwheel@v2.22.0
         env:
           CIBW_PRERELEASE_PYTHONS: "true"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,25 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  test_python_3_12:
-    runs-on: ubuntu-latest
-    steps:
-    - name: GitHub Checkout
-      uses: actions/checkout@v4
-
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "3.12"
-
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pytest pytest-cov
-        pip install -r packages/ubdcc-shared-modules/requirements.txt
-
-    - name: Unit test
-      run: pytest --cov --cov-branch --cov-report=xml unittest_ubdcc.py -v
-
   test_python_3_14:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- All 4 cibuildwheel workflows: build only `cp314-*`
- Unit tests: single job on Python 3.14 (removed 3.12 job)
- Cluster runs in controlled Docker environment, 3.14 is stable enough