### PR TITLE
Remove remaining LUCIT references outside docs/

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: | 
-        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/LUCIT-Systems-and-Development/unicorn-binance-suite/wiki/Issue-Guidelines). 
+        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Issue-Guidelines). 
         
         Most of these fields are not mandatory, but please provide as much information as possible.
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -11,7 +11,4 @@ contact_links:
     about: The complete UNICORN Binance DepthCache Cluster documentation.
   - name: Get Professional and Fast Support
     url: https://about.me/oliver-zehentleitner/get-support.html
-    about: Contact the LUCIT Development Team.
-  - name: Get a UNICORN Trading Suite License
-    url: https://github.com/oliver-zehentleitner/unicorn-trading-suite
-    about: LUCIT Online Shop
+    about: Contact the development team.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -7,7 +7,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/LUCIT-Systems-and-Development/unicorn-trading-suite/wiki/Issue-Guidelines). 
+        Please post here only issues concerning this repository and follow the [Issue-Guidelines](https://github.com/oliver-zehentleitner/unicorn-binance-suite/wiki/Issue-Guidelines). 
         
         Most of these fields are not mandatory, but please provide as much information as possible.
   - type: textarea

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,4 @@
-Contributions via GitHub pull requests are welcome. However, contributors should be aware that submitted code
-automatically becomes LUCIT IT-Management GmbH's property and copyright.
+Contributions via GitHub pull requests are welcome.
 
 Please read [our license terms](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE) 
 thoroughly!
@@ -43,9 +42,8 @@ thoroughly!
 <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 
-- [ ] I understand that the exploitation right of my donated code is transferred to the LUCIT company according to the 
-[MIT license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE) 
-agreement. This is important so that we can publish your code in our packages.
+- [ ] I understand that my contribution is licensed under the 
+[MIT license](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE).
 - [ ] My code follows the code style of this project.
 - [ ] My change requires a change to the documentation.
 - [ ] I have updated the documentation accordingly.

--- a/container/dev_station/LICENSE
+++ b/container/dev_station/LICENSE
@@ -1,115 +1,21 @@
-MIT
-============================================
+MIT License
 
-Version 1.0, November 2023
+Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 
-1. INTRODUCTION
-2. PROJECT INFORMATION
-3. LICENSE CONDITIONS AND VERIFICATION
-4. LICENSE PURCHASE
-5. CONTRIBUTING CODE
-6. USAGE AND DISTRIBUTION
-7. DATA COLLECTION AND LICENSE CONTROL
-8. THIRD-PARTY SOFTWARE
-9. DISCLAIMER OF WARRANTY AND LIABILITY
-10. CHANGES TO LICENSE TERMS
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-------------------------------------------------------------------------------------------------------------------------
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-1. INTRODUCTION
-
-The "LUCIT Synergetic Open Source License" oversees the utilization and distribution of the UNICORN Binance
-DepthCache Cluster and all its modules (ubdcc-dcn, ubdcc-mgmt, ubdcc-restapi,
-ubdcc-shared-modules) and Docker images (ubdcc-generic_loader) by LUCIT IT-Management GmbH.
-
-
-2. PROJECT INFORMATION
-
-- Project name: UNICORN Binance DepthCache Cluster
-- Project page: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-- GitHub repository: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-- PyPI repository:
-    - https://pypi.org/project/ubdcc-dcn
-    - https://pypi.org/project/ubdcc-mgmt
-    - https://pypi.org/project/ubdcc-restapi
-    - https://pypi.org/project/ubdcc-shared-modules
-
-- Get a license: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-
-
-3. LICENSE CONDITIONS AND VERIFICATION
-
-The use of UNICORN Binance DepthCache Cluster requires a license key and an API secret.
-
-Licenses are available at: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-
-Verification is done via a client-side module that forwards the license details to our backend for validation.
-The software may be used and distributed without restriction, the only condition is that the execution requires a valid
-license from LUCIT (https://github.com/oliver-zehentleitner) and must be operated with such a license.
-
-For transparency, our licensing client module is available on GitHub:
-https://github.com/LUCIT-Systems-and-Development/lucit-licensing-python
-
-
-4. LICENSE PURCHASE
-
-Usage of the our software necessitates obtaining a license from the LUCIT Online Shop.
-
-More details can be found at: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-
-
-5. CONTRIBUTING CODE
-
-Contributions via GitHub pull requests are welcome. However, contributors should be aware that submitted code
-automatically becomes LUCIT IT-Management GmbH's property and copyright.
-
-
-6. USAGE AND DISTRIBUTION
-
-The MIT licensed projects of LUCIT IT-Management GmbH can be used and integrated into any application without
-restriction and distributed as desired. The only condition is that the execution of our software requires a valid
-license from LUCIT (https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) and must be operated
-with such a license.
-
-For information on library versions that do not contain a license requirement, please contact: sales@lucit.tech
-
-
-7. DATA COLLECTION AND LICENSE CONTROL
-
-For license adherence, test license misuse prevention, API rate monitoring, and service improvement, we gather:
-
-- User IP addresses
-- Instance log data
-- Used Python version
-- Operating system type
-- API usage rates
-- MAC addresses (for misuse detection)
-- Data volume processed (anonymously aggregated)
-
-This data is stored only for its intended purpose and duration, except for anonymous statistics. We commit to
-confidentiality and non-disclosure. Details are in our privacy policy.
-
-
-8. THIRD-PARTY SOFTWARE
-
-The software may embed third-party code or libraries, each governed by their respective licenses. Ensure awareness and
-compliance when using the software.
-
-
-9. DISCLAIMER OF WARRANTY AND LIABILITY
-
-The software is rendered "as is", sans any assurances. LUCIT IT-Management GmbH disclaims liability for any potential
-repercussions arising from software usage.
-
-
-10. CHANGES TO LICENSE TERMS
-
-LUCIT IT-Management GmbH reserves the right to modify, alter, or update the terms of this license at any time and at
-its sole discretion. Users are encouraged to review the license terms regularly to ensure compliance.
-
-------------------------------------------------------------------------------------------------------------------------
-
-Thank you for selecting the UNICORN Binance DepthCache Cluster and products from LUCIT IT-Management GmbH. We deeply value
-your trust in our technologies.
-
-LUCIT IT-Management GmbH - Am Berg 391, 3970 Weitra, AUSTRIA - https://about.me/oliver-zehentleitner
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/container/dev_station/README.md
+++ b/container/dev_station/README.md
@@ -1,7 +1,5 @@
 # ***IN DEVELOPMENT!!!***
 
-[![Get a UNICORN DepthCache Cluster for Binance License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-License-Offer.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
-
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-depth-cache-cluster?color=blue)](https://pypi.org/project/unicorn-binance-depth-cache-cluster/)
@@ -18,22 +16,13 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Get Free Professional Support](
-
-[![LUCIT-UBDCC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 
 # UNICORN Binance DepthCache Cluster - UBDCC Dev Station (Docker Image)
 
 [Description](#description) | [Installation](#installation-and-upgrade) | [How To](#howto) | 
 [Documentation](#documentation) | [Examples](#examples) | [Change Log](#change-log) | [Wiki](#wiki) | 
 [Social](#social) | [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
-[Contributing](#contributing) | [Disclaimer](#disclaimer) | [Commercial Support](#commercial-support)
-
-[Get help](https://about.me/oliver-zehentleitner/get-support.html)!
-
-## Get a UNICORN Binance DepthCache Cluster License
-
-
+[Contributing](#contributing) | [Disclaimer](#disclaimer)
 
 ## How to report Bugs or suggest Improvements?
 [List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
@@ -67,9 +56,3 @@ jurisdiction.
 
 Under no circumstances will we be responsible or liable for any claims, damages, losses, expenses, costs or liabilities 
 of any kind, including but not limited to direct or indirect damages for loss of profits.
-
-## Commercial Support
-
-[![Get professional and fast support](https://raw.githubusercontent.com/LUCIT-Systems-and-Development/unicorn-trading-suite/master/images/support/LUCIT-get-professional-and-fast-support.png)](https://about.me/oliver-zehentleitner/get-support.html)
-
-***Do you need a developer, operator or consultant?*** [Contact us](https://about.me/oliver-zehentleitner/contact.html) for a non-binding initial consultation!

--- a/container/generic_loader/LICENSE
+++ b/container/generic_loader/LICENSE
@@ -1,115 +1,21 @@
-MIT
-============================================
+MIT License
 
-Version 1.0, November 2023
+Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 
-1. INTRODUCTION
-2. PROJECT INFORMATION
-3. LICENSE CONDITIONS AND VERIFICATION
-4. LICENSE PURCHASE
-5. CONTRIBUTING CODE
-6. USAGE AND DISTRIBUTION
-7. DATA COLLECTION AND LICENSE CONTROL
-8. THIRD-PARTY SOFTWARE
-9. DISCLAIMER OF WARRANTY AND LIABILITY
-10. CHANGES TO LICENSE TERMS
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-------------------------------------------------------------------------------------------------------------------------
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-1. INTRODUCTION
-
-The "LUCIT Synergetic Open Source License" oversees the utilization and distribution of the UNICORN Binance
-DepthCache Cluster and all its modules (ubdcc-dcn, ubdcc-mgmt, ubdcc-restapi,
-ubdcc-shared-modules) and Docker images (ubdcc-generic_loader) by LUCIT IT-Management GmbH.
-
-
-2. PROJECT INFORMATION
-
-- Project name: UNICORN Binance DepthCache Cluster
-- Project page: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-- GitHub repository: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-- PyPI repository:
-    - https://pypi.org/project/ubdcc-dcn
-    - https://pypi.org/project/ubdcc-mgmt
-    - https://pypi.org/project/ubdcc-restapi
-    - https://pypi.org/project/ubdcc-shared-modules
-
-- Get a license: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-
-
-3. LICENSE CONDITIONS AND VERIFICATION
-
-The use of UNICORN Binance DepthCache Cluster requires a license key and an API secret.
-
-Licenses are available at: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-
-Verification is done via a client-side module that forwards the license details to our backend for validation.
-The software may be used and distributed without restriction, the only condition is that the execution requires a valid
-license from LUCIT (https://github.com/oliver-zehentleitner) and must be operated with such a license.
-
-For transparency, our licensing client module is available on GitHub:
-https://github.com/LUCIT-Systems-and-Development/lucit-licensing-python
-
-
-4. LICENSE PURCHASE
-
-Usage of the our software necessitates obtaining a license from the LUCIT Online Shop.
-
-More details can be found at: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-
-
-5. CONTRIBUTING CODE
-
-Contributions via GitHub pull requests are welcome. However, contributors should be aware that submitted code
-automatically becomes LUCIT IT-Management GmbH's property and copyright.
-
-
-6. USAGE AND DISTRIBUTION
-
-The MIT licensed projects of LUCIT IT-Management GmbH can be used and integrated into any application without
-restriction and distributed as desired. The only condition is that the execution of our software requires a valid
-license from LUCIT (https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance) and must be operated
-with such a license.
-
-For information on library versions that do not contain a license requirement, please contact: sales@lucit.tech
-
-
-7. DATA COLLECTION AND LICENSE CONTROL
-
-For license adherence, test license misuse prevention, API rate monitoring, and service improvement, we gather:
-
-- User IP addresses
-- Instance log data
-- Used Python version
-- Operating system type
-- API usage rates
-- MAC addresses (for misuse detection)
-- Data volume processed (anonymously aggregated)
-
-This data is stored only for its intended purpose and duration, except for anonymous statistics. We commit to
-confidentiality and non-disclosure. Details are in our privacy policy.
-
-
-8. THIRD-PARTY SOFTWARE
-
-The software may embed third-party code or libraries, each governed by their respective licenses. Ensure awareness and
-compliance when using the software.
-
-
-9. DISCLAIMER OF WARRANTY AND LIABILITY
-
-The software is rendered "as is", sans any assurances. LUCIT IT-Management GmbH disclaims liability for any potential
-repercussions arising from software usage.
-
-
-10. CHANGES TO LICENSE TERMS
-
-LUCIT IT-Management GmbH reserves the right to modify, alter, or update the terms of this license at any time and at
-its sole discretion. Users are encouraged to review the license terms regularly to ensure compliance.
-
-------------------------------------------------------------------------------------------------------------------------
-
-Thank you for selecting the UNICORN Binance DepthCache Cluster and products from LUCIT IT-Management GmbH. We deeply value
-your trust in our technologies.
-
-LUCIT IT-Management GmbH - Am Berg 391, 3970 Weitra, AUSTRIA - https://about.me/oliver-zehentleitner
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/container/generic_loader/README.md
+++ b/container/generic_loader/README.md
@@ -1,7 +1,5 @@
 # ***IN DEVELOPMENT!!!***
 
-[![Get a UNICORN DepthCache Cluster for Binance License](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-License-Offer.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
-
 [![GitHub Release](https://img.shields.io/github/release/oliver-zehentleitner/unicorn-binance-depth-cache-cluster.svg?label=github)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![GitHub Downloads](https://img.shields.io/github/downloads/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/total?color=blue)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/releases)
 [![PyPi Release](https://img.shields.io/pypi/v/unicorn-binance-depth-cache-cluster?color=blue)](https://pypi.org/project/unicorn-binance-depth-cache-cluster/)
@@ -18,22 +16,13 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Get Free Professional Support](
-
-[![LUCIT-UBDCC-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/logo/LUCIT-UBDCC-Banner-Readme.png)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 
 # UNICORN Binance DepthCache Cluster - UBDCC Generic Loader (Docker Image)
 
 [Description](#description) | [Installation](#installation-and-upgrade) | [How To](#howto) | 
 [Documentation](#documentation) | [Examples](#examples) | [Change Log](#change-log) | [Wiki](#wiki) | 
 [Social](#social) | [Notifications](#receive-notifications) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
-[Contributing](#contributing) | [Disclaimer](#disclaimer) | [Commercial Support](#commercial-support)
-
-[Get help](https://about.me/oliver-zehentleitner/get-support.html)!
-
-## Get a UNICORN Binance DepthCache Cluster License
-
-
+[Contributing](#contributing) | [Disclaimer](#disclaimer)
 
 ## How to report Bugs or suggest Improvements?
 [List of planned features](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement) - click ![thumbs-up](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/master/images/misc/thumbup.png) if you need one of them or suggest a new feature!
@@ -67,9 +56,3 @@ jurisdiction.
 
 Under no circumstances will we be responsible or liable for any claims, damages, losses, expenses, costs or liabilities 
 of any kind, including but not limited to direct or indirect damages for loss of profits.
-
-## Commercial Support
-
-[![Get professional and fast support](https://raw.githubusercontent.com/LUCIT-Systems-and-Development/unicorn-trading-suite/master/images/support/LUCIT-get-professional-and-fast-support.png)](https://about.me/oliver-zehentleitner/get-support.html)
-
-***Do you need a developer, operator or consultant?*** [Contact us](https://about.me/oliver-zehentleitner/contact.html) for a non-binding initial consultation!

--- a/container/generic_loader/start_ubdcc_dcn.py
+++ b/container/generic_loader/start_ubdcc_dcn.py
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE

--- a/container/generic_loader/start_ubdcc_mgmt.py
+++ b/container/generic_loader/start_ubdcc_mgmt.py
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE

--- a/container/generic_loader/start_ubdcc_restapi.py
+++ b/container/generic_loader/start_ubdcc_restapi.py
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE

--- a/dev/pypi/create_wheel.sh
+++ b/dev/pypi/create_wheel.sh
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
 # PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE

--- a/dev/pypi/install_packaging_tools.sh
+++ b/dev/pypi/install_packaging_tools.sh
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
 # PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE

--- a/dev/pypi/remove_files.sh
+++ b/dev/pypi/remove_files.sh
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
 # PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE

--- a/dev/pypi/upload_wheel.sh
+++ b/dev/pypi/upload_wheel.sh
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
 # PyPI: https://pypi.org/project/unicorn-depthcache-cluster-for-binance
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE

--- a/dev/sphinx/create_docs.sh
+++ b/dev/sphinx/create_docs.sh
@@ -8,7 +8,6 @@
 # Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
 # Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
 # PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
-# LUCIT Online Shop: https://github.com/oliver-zehentleitner
 #
 # License: MIT
 # https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE


### PR DESCRIPTION
## Summary
- Replace old LUCIT license files in `container/` with proper MIT license
- Clean `container/` READMEs: remove license offer image, LUCIT banner, license purchase section, commercial support section
- Update PR template: remove LUCIT copyright transfer language
- Update issue templates: remove LUCIT URLs and online shop references
- Remove "LUCIT Online Shop" header line from all Python/shell scripts in `container/` and `dev/`

Only historical references in CHANGELOG.md and project notes (AGENTS.md/TASKS.md) remain. The `docs/` folder is excluded (needs full Sphinx rebuild).