### PR TITLE
Support both GET and POST for /create_depthcaches

### DIFF
--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -17,6 +17,7 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
+import base64
 import orjson as json
 from ubdcc_shared_modules.Database import Database
 from ubdcc_shared_modules.RestEndpointsBase import RestEndpointsBase, Request
@@ -138,7 +139,7 @@ class RestEndpoints(RestEndpointsBase):
         else:
             exchange = request.query_params.get("exchange", None)
             markets_param = request.query_params.get("markets", None)
-            markets = markets_param.split(",") if markets_param else None
+            markets = json.loads(base64.b64decode(markets_param)) if markets_param else None
             desired_quantity = request.query_params.get("desired_quantity", None)
             update_interval = request.query_params.get("update_interval", None)
             refresh_interval = request.query_params.get("refresh_interval", None)

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -35,7 +35,11 @@ class RestEndpoints(RestEndpointsBase):
             return await self.create_depthcache(request=request)
 
         @self.fastapi.post("/create_depthcaches")
-        async def create_depthcaches(request: Request):
+        async def create_depthcaches_post(request: Request):
+            return await self.create_depthcaches(request=request)
+
+        @self.fastapi.get("/create_depthcaches")
+        async def create_depthcaches_get(request: Request):
             return await self.create_depthcaches(request=request)
 
         @self.fastapi.get("/get_cluster_info")
@@ -124,12 +128,20 @@ class RestEndpoints(RestEndpointsBase):
         ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
         if ready_check is not None:
             return ready_check
-        body = json.loads(await request.body())
-        exchange = body.get("exchange", None)
-        markets = body.get("markets", None)
-        desired_quantity = body.get("desired_quantity", None)
-        update_interval = body.get("update_interval", None)
-        refresh_interval = body.get("refresh_interval", None)
+        if request.method == "POST":
+            body = json.loads(await request.body())
+            exchange = body.get("exchange", None)
+            markets = body.get("markets", None)
+            desired_quantity = body.get("desired_quantity", None)
+            update_interval = body.get("update_interval", None)
+            refresh_interval = body.get("refresh_interval", None)
+        else:
+            exchange = request.query_params.get("exchange", None)
+            markets_param = request.query_params.get("markets", None)
+            markets = markets_param.split(",") if markets_param else None
+            desired_quantity = request.query_params.get("desired_quantity", None)
+            update_interval = request.query_params.get("update_interval", None)
+            refresh_interval = request.query_params.get("refresh_interval", None)
         if exchange == "None":
             exchange = None
         if markets == "None":

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -17,7 +17,6 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
-import base64
 import orjson as json
 from ubdcc_shared_modules.Database import Database
 from ubdcc_shared_modules.RestEndpointsBase import RestEndpointsBase, Request
@@ -139,7 +138,7 @@ class RestEndpoints(RestEndpointsBase):
         else:
             exchange = request.query_params.get("exchange", None)
             markets_param = request.query_params.get("markets", None)
-            markets = json.loads(base64.b64decode(markets_param)) if markets_param else None
+            markets = markets_param.split(",") if markets_param else None
             desired_quantity = request.query_params.get("desired_quantity", None)
             update_interval = request.query_params.get("update_interval", None)
             refresh_interval = request.query_params.get("refresh_interval", None)

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -33,7 +33,11 @@ class RestEndpoints(RestEndpointsBase):
             return await self.create_depthcache(request=request)
 
         @self.fastapi.post("/create_depthcaches")
-        async def create_depthcaches(request: Request):
+        async def create_depthcaches_post(request: Request):
+            return await self.create_depthcaches(request=request)
+
+        @self.fastapi.get("/create_depthcaches")
+        async def create_depthcaches_get(request: Request):
             return await self.create_depthcaches(request=request)
 
         @self.fastapi.get("/get_asks")
@@ -152,9 +156,14 @@ class RestEndpoints(RestEndpointsBase):
         request_url = str(request.url)
         used_pods: list = [[self.app.id['name'], self.app.id['uid']]]
         host = self.app.get_cluster_mgmt_address()
-        body = await request.json()
-        url = host + endpoint
-        result = await self.app.request(url=url, method="post", params=body)
+        if request.method == "POST":
+            body = await request.json()
+            url = host + endpoint
+            result = await self.app.request(url=url, method="post", params=body)
+        else:
+            query = str(request.url.query)
+            url = host + endpoint + "?" + query
+            result = await self.app.request(url=url, method="get")
         if result.get('error') is not None and result.get('error_id') is not None:
             return self.get_error_response(event=event, error_id="#9000", message=f"Mgmt service not available!",
                                            params={"error": str(result)}, process_start_time=process_start_time,


### PR DESCRIPTION
## Summary
- Register both GET and POST routes for `/create_depthcaches` in restapi and mgmt
- GET accepts markets as comma-separated query param for easy browser debugging:
  `/create_depthcaches?exchange=binance.com&markets=BTCUSDT,ETHUSDT&desired_quantity=2`
- POST with JSON body remains the primary method for programmatic use
- restapi forwards GET as GET (query params) and POST as POST (JSON body) to mgmt