### PR TITLE
Highlight simplicity in README intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@
 # UNICORN Binance DepthCache Cluster (UBDCC)
 
 Manage hundreds of Binance order book depth caches and access them via REST API — from any programming language, 
-any number of clients, with load balancing and automatic failover.
+any number of clients, with load balancing and automatic failover. Simple to set up: `pip install`, start three 
+processes, done.
 
 Built on [UNICORN Binance Local Depth Cache (UBLDC)](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache). 
 Part of the [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).


### PR DESCRIPTION
## Summary
Add `pip install`, start three processes, done` to the opening line — it's genuinely that simple and should be communicated upfront.