### PR TITLE
Implement ubdcc CLI cluster manager

### DIFF
--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -24,8 +24,8 @@ from unicorn_binance_local_depth_cache.manager import __version__ as ubldc_versi
 
 
 class DepthCacheNode(ServiceBase):
-    def __init__(self, cwd=None):
-        super().__init__(app_name="ubdcc-dcn", cwd=cwd)
+    def __init__(self, cwd=None, mgmt_port=None):
+        super().__init__(app_name="ubdcc-dcn", cwd=cwd, mgmt_port=mgmt_port)
 
     async def main(self):
         self.app.data['depthcache_instances'] = {}

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
@@ -22,8 +22,8 @@ from ubdcc_shared_modules.ServiceBase import ServiceBase
 
 
 class Mgmt(ServiceBase):
-    def __init__(self, cwd=None):
-        super().__init__(app_name="ubdcc-mgmt", cwd=cwd)
+    def __init__(self, cwd=None, mgmt_port=None):
+        super().__init__(app_name="ubdcc-mgmt", cwd=cwd, mgmt_port=mgmt_port)
 
     async def main(self):
         self.db_init()

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
@@ -22,8 +22,8 @@ from ubdcc_shared_modules.ServiceBase import ServiceBase
 
 
 class RestApi(ServiceBase):
-    def __init__(self, cwd=None):
-        super().__init__(app_name="ubdcc-restapi", cwd=cwd)
+    def __init__(self, cwd=None, mgmt_port=None):
+        super().__init__(app_name="ubdcc-restapi", cwd=cwd, mgmt_port=mgmt_port)
 
     async def main(self):
         await self.start_rest_server(endpoints=RestEndpoints)

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -44,7 +44,8 @@ VERSION: str = "0.2.0"
 
 
 class App:
-    def __init__(self, app_name=None, cwd=None, logger=None, service=None, service_call=None, stop_call=None):
+    def __init__(self, app_name=None, cwd=None, mgmt_port=None, logger=None, service=None, service_call=None,
+                 stop_call=None):
         self.app_name = app_name
         self.app_version = VERSION
         self.api_port_rest: int = 0
@@ -62,7 +63,7 @@ class App:
         self.k8s_service_port_mgmt = K8S_SERVICE_PORT_MGMT
         self.rest_server_port = REST_SERVER_PORT
         self.rest_server_port_dev_dcn = REST_SERVER_PORT_DEV_DCN
-        self.rest_server_port_dev_mgmt = REST_SERVER_PORT_DEV_MGMT
+        self.rest_server_port_dev_mgmt = mgmt_port if mgmt_port is not None else REST_SERVER_PORT_DEV_MGMT
         self.rest_server_port_dev_restapi = REST_SERVER_PORT_DEV_RESTAPI
         self.service = service
         self.service_call = service_call
@@ -318,6 +319,8 @@ class App:
     def shutdown(self, message=None) -> None:
         self.sigterm = True
         self.stdout_msg(f"Shutdown is performed: {message}", log="warn")
+        if self.service is not None:
+            self.service.stop()
 
     def sigterm_handler(self, signal, frame) -> None:
         self.sigterm = True

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
@@ -119,6 +119,11 @@ class RestEndpointsBase:
         async def test(request: Request):
             return await self.test(request=request)
 
+        if self.app.dev_mode:
+            @self.fastapi.get("/shutdown")
+            async def shutdown(request: Request):
+                return await self.shutdown(request=request)
+
         @self.fastapi.get("/ubdcc_mgmt_backup")
         @self.fastapi.post("/ubdcc_mgmt_backup")
         async def ubdcc_mgmt_backup(request: Request):
@@ -138,6 +143,12 @@ class RestEndpointsBase:
                    "node": self.app.pod_info.spec.node_name}
             response['pod'] = pod
         return self.get_ok_response(event=event, params=response)
+
+    async def shutdown(self, request: Request):
+        event = "SHUTDOWN"
+        self.app.stdout_msg(f"Shutdown requested via REST endpoint!", log="info")
+        self.app.shutdown(message="Shutdown requested via REST endpoint")
+        return self.get_ok_response(event=event, params={"message": f"Shutting down pod '{self.app.id['name']}'..."})
 
     def throw_error_if_mgmt_not_ready(self, request: Request, event: str = None):
         if self.is_ready() is False:

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
@@ -25,11 +25,12 @@ from .Database import Database
 
 
 class ServiceBase:
-    def __init__(self, app_name=None, cwd=None):
+    def __init__(self, app_name=None, cwd=None, mgmt_port=None):
         self.db: Database | None = None
         self.rest_server = None
         self.app = App(app_name=app_name,
                        cwd=cwd,
+                       mgmt_port=mgmt_port,
                        service=self,
                        service_call=self.run,
                        stop_call=self.stop)

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -17,12 +17,278 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
-# TODO: Implement CLI - see TASKS.md for design discussion
+import argparse
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+
+import requests
+
+from ubdcc import __version__
+
+
+def is_port_free(port, host='127.0.0.1'):
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+            return True
+        except OSError:
+            return False
+
+
+def find_free_port(start=42080):
+    port = start
+    while not is_port_free(port):
+        port += 1
+    return port
+
+
+def wait_for_cluster(mgmt_port, expected_pods, timeout=120):
+    """Poll get_cluster_info until all expected pods are registered."""
+    url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            response = requests.get(url, timeout=5)
+            data = response.json()
+            if data.get('result') == 'OK' and data.get('db', {}).get('pods'):
+                registered = len(data['db']['pods'])
+                if registered >= expected_pods:
+                    return data
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            pass
+        time.sleep(1)
+    return None
+
+
+def cmd_start(args):
+    mgmt_port = args.port if args.port else find_free_port(42080)
+    dcn_count = args.dcn
+    logdir = args.logdir if args.logdir else os.getcwd()
+    os.makedirs(logdir, exist_ok=True)
+
+    print(f"UBDCC Cluster Manager v{__version__}")
+    print(f"Starting cluster with mgmt port {mgmt_port}, {dcn_count} DCN(s)...")
+    print(f"Log directory: {logdir}")
+
+    processes = []
+    cwd = os.getcwd()
+
+    # Start mgmt
+    mgmt_log = open(os.path.join(logdir, "ubdcc-mgmt.log"), "w")
+    mgmt_proc = subprocess.Popen(
+        [sys.executable, "-c",
+         f"import os; from ubdcc_mgmt.Mgmt import Mgmt; Mgmt(cwd='{cwd}', mgmt_port={mgmt_port})"],
+        stdout=mgmt_log, stderr=subprocess.STDOUT
+    )
+    processes.append(("mgmt", mgmt_proc, mgmt_log))
+    print(f"  mgmt started (PID {mgmt_proc.pid})")
+
+    # Start restapi
+    restapi_log = open(os.path.join(logdir, "ubdcc-restapi.log"), "w")
+    restapi_proc = subprocess.Popen(
+        [sys.executable, "-c",
+         f"import os; from ubdcc_restapi.RestApi import RestApi; RestApi(cwd='{cwd}', mgmt_port={mgmt_port})"],
+        stdout=restapi_log, stderr=subprocess.STDOUT
+    )
+    processes.append(("restapi", restapi_proc, restapi_log))
+    print(f"  restapi started (PID {restapi_proc.pid})")
+
+    # Start DCNs
+    for i in range(dcn_count):
+        dcn_log = open(os.path.join(logdir, f"ubdcc-dcn-{i+1}.log"), "w")
+        dcn_proc = subprocess.Popen(
+            [sys.executable, "-c",
+             f"import os; from ubdcc_dcn.DepthCacheNode import DepthCacheNode; "
+             f"DepthCacheNode(cwd='{cwd}', mgmt_port={mgmt_port})"],
+            stdout=dcn_log, stderr=subprocess.STDOUT
+        )
+        processes.append((f"dcn-{i+1}", dcn_proc, dcn_log))
+        print(f"  dcn-{i+1} started (PID {dcn_proc.pid})")
+
+    expected_pods = 1 + dcn_count  # restapi + DCNs (mgmt doesn't register itself)
+    print(f"\nWaiting for {expected_pods} pods to register with mgmt...")
+
+    cluster_info = wait_for_cluster(mgmt_port, expected_pods)
+    if cluster_info:
+        print(f"Cluster is ready!\n")
+        print_status_table(cluster_info)
+    else:
+        print("Warning: Timeout waiting for all pods to register. Check the logs.")
+
+    print(f"\nCluster is running. Use 'ubdcc status --port {mgmt_port}' to check.")
+    print(f"Use 'ubdcc stop --port {mgmt_port}' to shut down.\n")
+
+    # Keep running, wait for Ctrl+C
+    def signal_handler(sig, frame):
+        print("\nReceived interrupt, shutting down cluster...")
+        shutdown_all(mgmt_port)
+        for name, proc, log in processes:
+            proc.terminate()
+            log.close()
+        sys.exit(0)
+
+    signal.signal(signal.SIGINT, signal_handler)
+    signal.signal(signal.SIGTERM, signal_handler)
+
+    try:
+        while True:
+            # Check if any process died
+            for name, proc, log in processes:
+                if proc.poll() is not None:
+                    print(f"Warning: {name} (PID {proc.pid}) has exited with code {proc.returncode}")
+            time.sleep(5)
+    except KeyboardInterrupt:
+        signal_handler(None, None)
+
+
+def cmd_status(args):
+    mgmt_port = args.port if args.port else 42080
+    url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
+    try:
+        response = requests.get(url, timeout=5)
+        data = response.json()
+        if data.get('result') == 'OK':
+            print_status_table(data)
+        else:
+            print(f"Error: {data.get('message', 'Unknown error')}")
+    except requests.exceptions.ConnectionError:
+        print(f"Cannot connect to mgmt on port {mgmt_port}. Is the cluster running?")
+
+
+def cmd_stop(args):
+    mgmt_port = args.port if args.port else 42080
+    shutdown_all(mgmt_port)
+
+
+def cmd_restart(args):
+    mgmt_port = args.port if args.port else 42080
+    target = args.name
+    url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
+    try:
+        response = requests.get(url, timeout=5)
+        data = response.json()
+    except requests.exceptions.ConnectionError:
+        print(f"Cannot connect to mgmt on port {mgmt_port}. Is the cluster running?")
+        return
+
+    pods = data.get('db', {}).get('pods', {})
+    for uid, pod in pods.items():
+        if pod['NAME'] == target or uid == target:
+            port = pod['API_PORT_REST']
+            name = pod['NAME']
+            try:
+                requests.get(f"http://127.0.0.1:{port}/shutdown", timeout=5)
+                print(f"Shutdown signal sent to '{name}' on port {port}.")
+                print(f"Note: Restart the process manually or re-run 'ubdcc start'.")
+            except requests.exceptions.ConnectionError:
+                print(f"Cannot connect to '{name}' on port {port}.")
+            return
+
+    print(f"Pod '{target}' not found. Use 'ubdcc status' to see available pods.")
+
+
+def shutdown_all(mgmt_port):
+    """Shutdown all pods via their /shutdown endpoints."""
+    url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
+    try:
+        response = requests.get(url, timeout=5)
+        data = response.json()
+    except requests.exceptions.ConnectionError:
+        print(f"Cannot connect to mgmt on port {mgmt_port}.")
+        return
+
+    pods = data.get('db', {}).get('pods', {})
+    for uid, pod in pods.items():
+        port = pod['API_PORT_REST']
+        name = pod['NAME']
+        try:
+            requests.get(f"http://127.0.0.1:{port}/shutdown", timeout=3)
+            print(f"  Shutdown: {name} ({pod['ROLE']}) on port {port}")
+        except requests.exceptions.ConnectionError:
+            print(f"  Warning: Could not reach {name} on port {port}")
+
+    # Shutdown mgmt last
+    try:
+        requests.get(f"http://127.0.0.1:{mgmt_port}/shutdown", timeout=3)
+        print(f"  Shutdown: mgmt on port {mgmt_port}")
+    except requests.exceptions.ConnectionError:
+        print(f"  Warning: Could not reach mgmt on port {mgmt_port}")
+
+    print("Cluster shutdown complete.")
+
+
+def print_status_table(data):
+    """Print a formatted status table from cluster info."""
+    pods = data.get('db', {}).get('pods', {})
+    if not pods:
+        print("No pods registered.")
+        return
+
+    print(f"{'ROLE':<16} {'NAME':<20} {'PORT':<8} {'STATUS':<10} {'VERSION'}")
+    print("-" * 70)
+
+    # Sort: mgmt first, then restapi, then dcn
+    role_order = {'ubdcc-mgmt': 0, 'ubdcc-restapi': 1, 'ubdcc-dcn': 2}
+    sorted_pods = sorted(pods.values(), key=lambda p: (role_order.get(p.get('ROLE', ''), 9), p.get('NAME', '')))
+
+    for pod in sorted_pods:
+        role = pod.get('ROLE', '?')
+        name = pod.get('NAME', '?')
+        port = pod.get('API_PORT_REST', '?')
+        status = pod.get('STATUS', '?')
+        version = pod.get('VERSION', '?')
+        print(f"{role:<16} {name:<20} {port:<8} {status:<10} {version}")
+
+    depthcaches = data.get('db', {}).get('depthcaches', {})
+    dc_count = sum(len(markets) for markets in depthcaches.values())
+    print(f"\nDepthCaches: {dc_count}")
+    print(f"Version: {data.get('version', '?')}")
 
 
 def main():
-    print("ubdcc cluster manager - not yet implemented")
-    print("See: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster")
+    parser = argparse.ArgumentParser(
+        prog='ubdcc',
+        description='UNICORN Binance DepthCache Cluster — Cluster Manager'
+    )
+    parser.add_argument('-v', '--version', action='version', version=f'ubdcc {__version__}')
+
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+
+    # start
+    start_parser = subparsers.add_parser('start', help='Start the cluster')
+    start_parser.add_argument('--dcn', type=int, default=1, help='Number of DCN processes (default: 1)')
+    start_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080 or next free)')
+    start_parser.add_argument('--logdir', type=str, default=None, help='Log directory (default: current directory)')
+
+    # status
+    status_parser = subparsers.add_parser('status', help='Show cluster status')
+    status_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
+
+    # stop
+    stop_parser = subparsers.add_parser('stop', help='Stop the cluster')
+    stop_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
+
+    # restart
+    restart_parser = subparsers.add_parser('restart', help='Restart a specific pod')
+    restart_parser.add_argument('name', help='Pod name or UID to restart')
+    restart_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
+
+    args = parser.parse_args()
+
+    if args.command == 'start':
+        cmd_start(args)
+    elif args.command == 'status':
+        cmd_status(args)
+    elif args.command == 'stop':
+        cmd_stop(args)
+    elif args.command == 'restart':
+        cmd_restart(args)
+    else:
+        parser.print_help()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

### New: `ubdcc` CLI commands
```bash
ubdcc start --dcn 4              # start mgmt + restapi + 4 DCNs
ubdcc status                     # show all pods with role, name, port, status
ubdcc stop                       # graceful shutdown via REST
ubdcc restart <pod-name>         # restart a specific pod
```

### Infrastructure
- `/shutdown` REST endpoint on all pods (dev-mode only)
- `App.shutdown()` now stops the REST server (uvicorn)
- `mgmt_port` parameter flows through App → ServiceBase → Mgmt/RestApi/DCN
- All 3 services accept optional `mgmt_port` in `__init__`

### How it works
1. CLI finds free port for mgmt (default 42080)
2. Spawns mgmt, restapi, DCN(s) as subprocesses with `mgmt_port` parameter
3. Polls `get_cluster_info` until all pods registered
4. Shows status table
5. `ubdcc stop` calls `/shutdown` on each pod via REST — no PID files, no signals