### PR TITLE
Add ubdcc package symlinks to dev scripts

### DIFF
--- a/dev/create_sym_links.sh
+++ b/dev/create_sym_links.sh
@@ -21,4 +21,10 @@ ln -s ../ubdcc-shared-modules/ubdcc_shared_modules .
 cd ubdcc_restapi
 ln -s ../ubdcc_shared_modules .
 
+cd ../../ubdcc/
+ln -s ../ubdcc-dcn/ubdcc_dcn .
+ln -s ../ubdcc-mgmt/ubdcc_mgmt .
+ln -s ../ubdcc-restapi/ubdcc_restapi .
+ln -s ../ubdcc-shared-modules/ubdcc_shared_modules .
+
 

--- a/dev/remove_sym_links.sh
+++ b/dev/remove_sym_links.sh
@@ -13,3 +13,8 @@ rm -f ./packages/ubdcc-mgmt/ubdcc_mgmt/ubdcc_shared_modules
 
 rm -f ./packages/ubdcc-restapi/ubdcc_shared_modules
 rm -f ./packages/ubdcc-restapi/ubdcc_restapi/ubdcc_shared_modules
+
+rm -f ./packages/ubdcc/ubdcc_dcn
+rm -f ./packages/ubdcc/ubdcc_mgmt
+rm -f ./packages/ubdcc/ubdcc_restapi
+rm -f ./packages/ubdcc/ubdcc_shared_modules


### PR DESCRIPTION
## Summary
Add symlinks for the ubdcc package to `dev/create_sym_links.sh` and `dev/remove_sym_links.sh` — links ubdcc_dcn, ubdcc_mgmt, ubdcc_restapi and ubdcc_shared_modules into the ubdcc package directory for local development.