### PR TITLE
Add __main__.py for 'python -m ubdcc' support

### DIFF
--- a/packages/ubdcc/ubdcc/__main__.py
+++ b/packages/ubdcc/ubdcc/__main__.py
@@ -1,0 +1,3 @@
+from ubdcc.cli import main
+
+main()


### PR DESCRIPTION
## Summary
Allows running `python -m ubdcc start --dcn 4` from the package directory without pip install.