### PR TITLE
Show mgmt in status table, display REST API URL

### DIFF
--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -29,6 +29,32 @@ import requests
 
 from ubdcc import __version__
 
+STATE_FILE = ".ubdcc"
+DEFAULT_MGMT_PORT = 42080
+
+
+def save_port(port):
+    with open(STATE_FILE, "w") as f:
+        f.write(str(port))
+
+
+def load_port():
+    try:
+        with open(STATE_FILE, "r") as f:
+            return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def get_mgmt_port(args):
+    """Resolve mgmt port: --port flag > state file > default."""
+    if args.port is not None:
+        return args.port
+    saved = load_port()
+    if saved is not None:
+        return saved
+    return DEFAULT_MGMT_PORT
+
 
 def is_port_free(port, host='127.0.0.1'):
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
@@ -65,10 +91,11 @@ def wait_for_cluster(mgmt_port, expected_pods, timeout=120):
 
 
 def cmd_start(args):
-    mgmt_port = args.port if args.port else find_free_port(42080)
+    mgmt_port = args.port if args.port else find_free_port(DEFAULT_MGMT_PORT)
     dcn_count = args.dcn
     logdir = args.logdir if args.logdir else os.getcwd()
     os.makedirs(logdir, exist_ok=True)
+    save_port(mgmt_port)
 
     print(f"UBDCC Cluster Manager v{__version__}")
     print(f"Starting cluster with mgmt port {mgmt_port}, {dcn_count} DCN(s)...")
@@ -119,8 +146,8 @@ def cmd_start(args):
     else:
         print("Warning: Timeout waiting for all pods to register. Check the logs.")
 
-    print(f"\nUse 'ubdcc status --port {mgmt_port}' to check.")
-    print(f"Use 'ubdcc stop --port {mgmt_port}' to shut down.\n")
+    print(f"\nUse 'ubdcc status' to check.")
+    print(f"Use 'ubdcc stop' to shut down.\n")
 
     # Keep running, wait for Ctrl+C
     def signal_handler(sig, frame):
@@ -146,7 +173,7 @@ def cmd_start(args):
 
 
 def cmd_status(args):
-    mgmt_port = args.port if args.port else 42080
+    mgmt_port = get_mgmt_port(args)
     url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
     try:
         response = requests.get(url, timeout=5)
@@ -160,12 +187,12 @@ def cmd_status(args):
 
 
 def cmd_stop(args):
-    mgmt_port = args.port if args.port else 42080
+    mgmt_port = get_mgmt_port(args)
     shutdown_all(mgmt_port)
 
 
 def cmd_restart(args):
-    mgmt_port = args.port if args.port else 42080
+    mgmt_port = get_mgmt_port(args)
     target = args.name
     url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
     try:

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -115,11 +115,11 @@ def cmd_start(args):
     cluster_info = wait_for_cluster(mgmt_port, expected_pods)
     if cluster_info:
         print(f"Cluster is ready!\n")
-        print_status_table(cluster_info)
+        print_status_table(cluster_info, mgmt_port=mgmt_port)
     else:
         print("Warning: Timeout waiting for all pods to register. Check the logs.")
 
-    print(f"\nCluster is running. Use 'ubdcc status --port {mgmt_port}' to check.")
+    print(f"\nUse 'ubdcc status --port {mgmt_port}' to check.")
     print(f"Use 'ubdcc stop --port {mgmt_port}' to shut down.\n")
 
     # Keep running, wait for Ctrl+C
@@ -152,7 +152,7 @@ def cmd_status(args):
         response = requests.get(url, timeout=5)
         data = response.json()
         if data.get('result') == 'OK':
-            print_status_table(data)
+            print_status_table(data, mgmt_port=mgmt_port)
         else:
             print(f"Error: {data.get('message', 'Unknown error')}")
     except requests.exceptions.ConnectionError:
@@ -221,20 +221,28 @@ def shutdown_all(mgmt_port):
     print("Cluster shutdown complete.")
 
 
-def print_status_table(data):
+def print_status_table(data, mgmt_port=42080):
     """Print a formatted status table from cluster info."""
     pods = data.get('db', {}).get('pods', {})
-    if not pods:
-        print("No pods registered.")
-        return
 
     print(f"{'ROLE':<16} {'NAME':<20} {'PORT':<8} {'STATUS':<10} {'VERSION'}")
     print("-" * 70)
 
-    # Sort: mgmt first, then restapi, then dcn
-    role_order = {'ubdcc-mgmt': 0, 'ubdcc-restapi': 1, 'ubdcc-dcn': 2}
+    # Get mgmt info via /test endpoint
+    try:
+        mgmt_response = requests.get(f"http://127.0.0.1:{mgmt_port}/test", timeout=3)
+        mgmt_data = mgmt_response.json()
+        mgmt_name = mgmt_data.get('app', {}).get('name', '?')
+        mgmt_version = mgmt_data.get('app', {}).get('version', '?')
+        print(f"{'ubdcc-mgmt':<16} {mgmt_name:<20} {mgmt_port:<8} {'running':<10} {mgmt_version}")
+    except requests.exceptions.ConnectionError:
+        print(f"{'ubdcc-mgmt':<16} {'?':<20} {mgmt_port:<8} {'down':<10} {'?'}")
+
+    # Sort: restapi first, then dcn
+    role_order = {'ubdcc-restapi': 0, 'ubdcc-dcn': 1}
     sorted_pods = sorted(pods.values(), key=lambda p: (role_order.get(p.get('ROLE', ''), 9), p.get('NAME', '')))
 
+    restapi_port = None
     for pod in sorted_pods:
         role = pod.get('ROLE', '?')
         name = pod.get('NAME', '?')
@@ -242,11 +250,16 @@ def print_status_table(data):
         status = pod.get('STATUS', '?')
         version = pod.get('VERSION', '?')
         print(f"{role:<16} {name:<20} {port:<8} {status:<10} {version}")
+        if role == 'ubdcc-restapi' and restapi_port is None:
+            restapi_port = port
 
     depthcaches = data.get('db', {}).get('depthcaches', {})
     dc_count = sum(len(markets) for markets in depthcaches.values())
     print(f"\nDepthCaches: {dc_count}")
     print(f"Version: {data.get('version', '?')}")
+    if restapi_port:
+        print(f"\nREST API: http://127.0.0.1:{restapi_port}/")
+        print(f"Cluster info: http://127.0.0.1:{restapi_port}/get_cluster_info")
 
 
 def main():


### PR DESCRIPTION
## Summary
- mgmt now appears in `ubdcc status` table (fetched via `/test` endpoint, since mgmt doesn't register itself)
- REST API URL and cluster info link shown after the table
- Example output:
```
ROLE             NAME                 PORT     STATUS     VERSION
----------------------------------------------------------------------
ubdcc-mgmt       ubdcc-mgmt           42080    running    0.2.0
ubdcc-restapi    TDMKiCnT6jZ39N       42081    running    0.2.0
ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.2.0
ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.2.0

DepthCaches: 4
Version: 0.2.0

REST API: http://127.0.0.1:42081/
Cluster info: http://127.0.0.1:42081/get_cluster_info
```