### PR TITLE
Set SO_REUSEADDR in is_port_free to handle TIME_WAIT

### DIFF
--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
@@ -47,6 +47,7 @@ class ServiceBase:
     @staticmethod
     def is_port_free(port, host='127.0.0.1'):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:
                 s.bind((host, port))
                 return True


### PR DESCRIPTION
## Summary
After `restart mgmt` on a custom port (e.g. 6666), the new mgmt landed on 6667 because the pre-check in `is_port_free()` saw the port in TIME_WAIT state as occupied and triggered auto-increment.

Fix: set `SO_REUSEADDR` on the check socket. uvicorn already uses it for the actual bind, so the port increment was spurious.