### PR TITLE
Write proper CHANGELOGs for all 5 packages

### DIFF
--- a/packages/ubdcc-dcn/CHANGELOG.md
+++ b/packages/ubdcc-dcn/CHANGELOG.md
@@ -1,7 +1,22 @@
 # ubdcc-dcn Change Log
 
-## 0.1.0
-```
+All notable changes to this package will be documented in this file.
 
-```
+## 0.2.1
 ### Added
+- `mgmt_port` parameter on `DepthCacheNode` — accepts custom port from the ubdcc CLI
+### Changed
+- Python support extended to 3.9-3.14 on Linux, macOS and Windows
+- Build workflow: migrated to UBWA pattern (3 OS matrix, cibuildwheel v3.4.1, sdist, GitHub Release)
+
+## 0.2.0
+### Changed
+- Rebranded from LUCIT to open source MIT
+- Renamed: `lucit-ubdcc-dcn` → `ubdcc-dcn`, namespace `lucit_ubdcc_dcn` → `ubdcc_dcn`
+- LICENSE: LSOSL → MIT
+- Author: LUCIT Systems and Development → Oliver Zehentleitner
+### Fixed
+- `create_depth_cache()` → `create_depthcache()` (deprecated UBLDC method call)
+- UBLDC dependency: pinned `==2.6.0` → `>=2.8.1`
+### Removed
+- License params (`lucit_api_secret`, `lucit_license_token`) from UBLDC instantiation

--- a/packages/ubdcc-mgmt/CHANGELOG.md
+++ b/packages/ubdcc-mgmt/CHANGELOG.md
@@ -1,7 +1,24 @@
 # ubdcc-mgmt Change Log
 
-## 0.1.0
-```
+All notable changes to this package will be documented in this file.
 
-```
+## 0.2.1
 ### Added
+- `/create_depthcaches` now supports both POST (JSON body, primary) and GET (base64-encoded markets, for browser debugging)
+- `mgmt_port` parameter on `Mgmt` — accepts custom port from the ubdcc CLI
+### Fixed
+- Remove double `import base64` that was left over after the orjson migration
+### Changed
+- Python support extended to 3.9-3.14 on Linux, macOS and Windows
+- Replaced `json` with `orjson` for faster JSON parsing (closes #5)
+- `/create_depthcaches` switched from GET to POST as primary method (closes #10) — prevents URL-too-long errors when creating many DepthCaches at once
+- Build workflow: migrated to UBWA pattern (3 OS matrix, cibuildwheel v3.4.1, sdist, GitHub Release)
+
+## 0.2.0
+### Changed
+- Rebranded from LUCIT to open source MIT
+- Renamed: `lucit-ubdcc-mgmt` → `ubdcc-mgmt`, namespace `lucit_ubdcc_mgmt` → `ubdcc_mgmt`
+- LICENSE: LSOSL → MIT
+- Author: LUCIT Systems and Development → Oliver Zehentleitner
+### Removed
+- `submit_license` endpoint (LUCIT licensing system)

--- a/packages/ubdcc-restapi/CHANGELOG.md
+++ b/packages/ubdcc-restapi/CHANGELOG.md
@@ -1,7 +1,23 @@
 # ubdcc-restapi Change Log
 
-## 0.1.0
-```
+All notable changes to this package will be documented in this file.
 
-```
+## 0.2.1
 ### Added
+- `/create_depthcaches` now supports both POST (JSON body, primary) and GET (query params, for browser debugging)
+- `mgmt_port` parameter on `RestApi` — accepts custom port from the ubdcc CLI
+- POST body is now included in `debug=true` response (`post_body` field)
+### Changed
+- Python support extended to 3.9-3.14 on Linux, macOS and Windows
+- Replaced `json` with `orjson` for faster JSON parsing
+- `/create_depthcaches` switched from GET to POST as primary method — forwards request body as-is to mgmt
+- Build workflow: migrated to UBWA pattern (3 OS matrix, cibuildwheel v3.4.1, sdist, GitHub Release)
+
+## 0.2.0
+### Changed
+- Rebranded from LUCIT to open source MIT
+- Renamed: `lucit-ubdcc-restapi` → `ubdcc-restapi`, namespace `lucit_ubdcc_restapi` → `ubdcc_restapi`
+- LICENSE: LSOSL → MIT
+- Author: LUCIT Systems and Development → Oliver Zehentleitner
+### Removed
+- `submit_license` endpoint (LUCIT licensing system)

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -1,7 +1,28 @@
 # ubdcc-shared-modules Change Log
 
-## 0.1.0
-```
+All notable changes to this package will be documented in this file.
 
-```
+## 0.2.1
 ### Added
+- `/shutdown` REST endpoint (dev-mode only) on all pods — triggers graceful process shutdown via REST
+- `mgmt_port` parameter on `App` and `ServiceBase` — allows custom mgmt port via CLI
+- `post_body` field in `create_debug_response()` — POST body now visible in `debug=true` response
+### Fixed
+- `/shutdown` endpoint now force-exits via `os._exit(0)` 0.5s after the response — previously processes could hang if the main loop was stuck in `asyncio.sleep`
+- `is_port_free()` now sets `SO_REUSEADDR` — TIME_WAIT state after a restart no longer blocks rebinding to the same port
+- Port retry on bind failure — `start_rest_server()` checks if the uvicorn thread is alive and tries the next port if not (fixes race condition when multiple DCNs start simultaneously)
+- Removed orphaned `except AttributeError` block leftover from LUCIT removal that caused Cython build failure
+### Changed
+- Python support extended to 3.9-3.14 on Linux, macOS and Windows
+- Replaced `json` with `orjson` for faster JSON parsing
+- Build workflow: migrated to UBWA pattern (3 OS matrix, cibuildwheel v3.4.1, sdist, GitHub Release)
+
+## 0.2.0
+### Changed
+- Rebranded from LUCIT to open source MIT
+- Renamed: `lucit-ubdcc-shared-modules` → `ubdcc-shared-modules`, namespace `lucit_ubdcc_shared_modules` → `ubdcc_shared_modules`
+- LICENSE: LSOSL → MIT
+- Author: LUCIT Systems and Development → Oliver Zehentleitner
+### Removed
+- LUCIT licensing system (`LicensingManager`, `LicensingExceptions`)
+- `lucit-licensing-python` dependency

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -1,7 +1,27 @@
 # UNICORN Binance DepthCache Cluster (ubdcc) Change Log
 
+All notable changes to this package will be documented in this file.
+
+## 0.2.1
+### Added
+- `ubdcc` CLI cluster manager with interactive console:
+  - `ubdcc start --dcn N [--port PORT] [--logdir DIR]` — spawn mgmt, restapi and N DCN processes
+  - `ubdcc status` — show all pods with role, name, port, status and version
+  - `ubdcc stop` — graceful shutdown of the entire cluster
+  - `ubdcc restart <name>` — full restart (shutdown + respawn) for mgmt, restapi or DCN
+  - Interactive `ubdcc>` prompt during `start`:
+    - `add-dcn [count]` — spawn new DCN process(es)
+    - `remove-dcn <count|name>` — stop DCN(s) by count or name
+    - `status`, `restart <name>`, `stop`, `help`
+- `python -m ubdcc` entry point for running from source during development
+- `.ubdcc` state file for automatic port detection across CLI commands
+- `--help` epilog listing all interactive shell commands
+- GitHub Release step in the build workflow
+### Changed
+- Python support extended to 3.9-3.14 on Linux, macOS and Windows
+- Workflow renamed to "Build and Publish GH+PyPi (ubdcc)" for consistency with other packages
+
 ## 0.2.0
 ### Added
-- Initial release as meta-package and cluster manager
+- Initial release as meta-package and cluster manager stub
 - Installs all UBDCC components: ubdcc-mgmt, ubdcc-restapi, ubdcc-dcn
-- `ubdcc` CLI command (cluster manager — work in progress)


### PR DESCRIPTION
## Summary
Previously the per-package CHANGELOGs were empty stubs at 0.1.0 while setup.py already showed 0.2.0. Now each has a complete history of 0.2.0 changes and the upcoming 0.2.1 release notes, ready for the GitHub Releases.

All 5 packages covered: ubdcc, ubdcc-shared-modules, ubdcc-mgmt, ubdcc-restapi, ubdcc-dcn.