### PR TITLE
Fix syntax error in Sphinx conf.py

### DIFF
--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -90,7 +90,7 @@ pygments_style = None
 html_theme = 'alabaster'
 html_context = {'github_user_name': 'oliver-zehentleitner',
                 'github_repo_name': 'unicorn-binance-depth-cache-cluster',
-                'project_name': project,
+                'project_name': project}
 
 myst_heading_anchors = 3
 


### PR DESCRIPTION
Missing closing `}` on html_context dict (line 91-93). Broke 'make html' with Sphinx 9.1.