### PR TITLE
Restore python_docs_theme_lucit for consistency with UBS

### DIFF
--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -87,10 +87,11 @@ pygments_style = None
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 
-html_theme = 'alabaster'
+html_theme = 'python_docs_theme_lucit'
 html_context = {'github_user_name': 'oliver-zehentleitner',
                 'github_repo_name': 'unicorn-binance-depth-cache-cluster',
                 'project_name': project,
+                'lucit': True}
 
 myst_heading_anchors = 3
 


### PR DESCRIPTION
## Summary
All other UBS projects (UBWA, UBLDC, UBRA, UBTSL, unicorn-fy) use `python_docs_theme_lucit`. UBDCC was the only one migrated to `alabaster` during LUCIT removal — this was inconsistent. Restore the theme.

Also fixes the syntax error in the incomplete `html_context` dict (missing `}` and `lucit: True` entry).