### PR TITLE
Fix Sphinx install script and CNAME generation

### DIFF
--- a/dev/sphinx/create_docs.sh
+++ b/dev/sphinx/create_docs.sh
@@ -3,14 +3,14 @@
 #
 # File: dev/sphinx/create_docs.sh
 #
-# Part of ‘UNICORN Binance Local Depth Cache’
-# Project website: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Github: https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance
-# Documentation: https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance
+# Part of ‘UNICORN Binance DepthCache Cluster’
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 # PyPI: https://pypi.org/project/unicorn-binance-depth-cache-cluster
 #
 # License: MIT
-# https://github.com/oliver-zehentleitner/unicorn-depthcache-cluster-for-binance/blob/master/LICENSE
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
 #
 # Author: Oliver Zehentleitner
 #
@@ -38,4 +38,4 @@ rm build/html
 ln -s ../../../docs build/html
 make html -d
 echo "Creating CNAME file for GitHub."
-echo "oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance" >> build/html/CNAME
+echo "oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster" > build/html/CNAME

--- a/dev/sphinx/install_sphinx.sh
+++ b/dev/sphinx/install_sphinx.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 python3 -m pip install sphinx --upgrade
-python3 -m pip install sphinx-rtd-theme --upgrade
+python3 -m pip install python-docs-theme-lucit --upgrade
 python3 -m pip install rich --upgrade
 python3 -m pip install myst-parser --upgrade
 python3 -m pip install sphinx-markdown-tables --upgrade


### PR DESCRIPTION
## Summary
- `install_sphinx.sh`: install `python-docs-theme-lucit` (matches conf.py) instead of `sphinx-rtd-theme`
- `create_docs.sh`: CNAME was appended (`>>`) instead of overwritten (`>`) — each run added another line
- `create_docs.sh`: update old repo URLs in file header