### PR TITLE
Fix 4 Sphinx warnings after LUCIT removal

### DIFF
--- a/dev/sphinx/create_docs.sh
+++ b/dev/sphinx/create_docs.sh
@@ -27,9 +27,18 @@ rm dev/sphinx/source/security.md
 cp CHANGELOG.md dev/sphinx/source/changelog.md
 cp CODE_OF_CONDUCT.md dev/sphinx/source/code_of_conduct.md
 cp CONTRIBUTING.md dev/sphinx/source/contributing.md
-cp LICENSE dev/sphinx/source/license.rst
 cp README.md dev/sphinx/source/readme.md
 cp SECURITY.md dev/sphinx/source/security.md
+
+# license.rst needs a reST title
+{
+    echo "License"
+    echo "======="
+    echo ""
+    echo "::"
+    echo ""
+    sed 's/^/    /' LICENSE
+} > dev/sphinx/source/license.rst
 
 mkdir -vp dev/sphinx/build
 

--- a/dev/sphinx/install_sphinx.sh
+++ b/dev/sphinx/install_sphinx.sh
@@ -4,3 +4,4 @@ python3 -m pip install python-docs-theme-lucit --upgrade
 python3 -m pip install rich --upgrade
 python3 -m pip install myst-parser --upgrade
 python3 -m pip install sphinx-markdown-tables --upgrade
+python3 -m pip install sphinxcontrib-mermaid --upgrade

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -51,6 +51,7 @@ extensions = [
     'sphinx_markdown_tables',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.mermaid',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/dev/sphinx/source/ubdcc_shared_modules.rst
+++ b/dev/sphinx/source/ubdcc_shared_modules.rst
@@ -20,22 +20,6 @@ ubdcc_shared\_modules.Database module
    :undoc-members:
    :show-inheritance:
 
-ubdcc_shared\_modules.LicensingExceptions module
---------------------------------------------------------
-
-.. automodule:: ubdcc_shared_modules.LicensingExceptions
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
-ubdcc_shared\_modules.LicensingManager module
------------------------------------------------------
-
-.. automodule:: ubdcc_shared_modules.LicensingManager
-   :members:
-   :undoc-members:
-   :show-inheritance:
-
 ubdcc_shared\_modules.RestEndpointsBase module
 ------------------------------------------------------
 


### PR DESCRIPTION
## Summary
Fix all 4 warnings from `make html`:

1. `ubdcc_shared_modules.LicensingExceptions` not found → removed autodoc entry
2. `ubdcc_shared_modules.LicensingManager` not found → removed autodoc entry
3. `license.rst has no title` → generate license.rst with reST title wrapping LICENSE file
4. `Pygments Lexer 'mermaid' unknown` → add `sphinxcontrib-mermaid` extension