### PR TITLE
Fix Mermaid warning via myst_fence_as_directive

### DIFF
--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -95,6 +95,7 @@ html_context = {'github_user_name': 'oliver-zehentleitner',
                 'lucit': True}
 
 myst_heading_anchors = 3
+myst_fence_as_directive = ["mermaid"]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
## Summary
After PR #65 added `sphinxcontrib-mermaid`, the mermaid warning still appeared because MyST was still treating ` ```mermaid ` blocks as regular code fences.

Fix: `myst_fence_as_directive = ["mermaid"]` tells MyST to forward mermaid fences to the Sphinx directive.

Tested locally — `make html` now produces zero warnings.