### PR TITLE
Force bash shell in workflow steps for Windows runner

### DIFF
--- a/.github/workflows/build_wheels_ubdcc_dcn.yml
+++ b/.github/workflows/build_wheels_ubdcc_dcn.yml
@@ -27,11 +27,13 @@ jobs:
           sparse-checkout: 'packages/ubdcc-dcn/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-dcn/packages/ubdcc-dcn/* ./
           rm -rf ubdcc-dcn
 
       - name: ls -l
+        shell: bash
         run: ls -l
 
       - name: Upgrade pip
@@ -74,6 +76,7 @@ jobs:
           sparse-checkout: 'packages/ubdcc-dcn/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-dcn/packages/ubdcc-dcn/* ./
           rm -rf ubdcc-dcn

--- a/.github/workflows/build_wheels_ubdcc_mgmt.yml
+++ b/.github/workflows/build_wheels_ubdcc_mgmt.yml
@@ -27,11 +27,13 @@ jobs:
           sparse-checkout: 'packages/ubdcc-mgmt/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-mgmt/packages/ubdcc-mgmt/* ./
           rm -rf ubdcc-mgmt
 
       - name: ls -l
+        shell: bash
         run: ls -l
 
       - name: Upgrade pip
@@ -74,6 +76,7 @@ jobs:
           sparse-checkout: 'packages/ubdcc-mgmt/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-mgmt/packages/ubdcc-mgmt/* ./
           rm -rf ubdcc-mgmt

--- a/.github/workflows/build_wheels_ubdcc_restapi.yml
+++ b/.github/workflows/build_wheels_ubdcc_restapi.yml
@@ -27,11 +27,13 @@ jobs:
           sparse-checkout: 'packages/ubdcc-restapi/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-restapi/packages/ubdcc-restapi/* ./
           rm -rf ubdcc-restapi
 
       - name: ls -l
+        shell: bash
         run: ls -l
 
       - name: Upgrade pip
@@ -74,6 +76,7 @@ jobs:
           sparse-checkout: 'packages/ubdcc-restapi/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-restapi/packages/ubdcc-restapi/* ./
           rm -rf ubdcc-restapi

--- a/.github/workflows/build_wheels_ubdcc_shared_modules.yml
+++ b/.github/workflows/build_wheels_ubdcc_shared_modules.yml
@@ -27,11 +27,13 @@ jobs:
           sparse-checkout: 'packages/ubdcc-shared-modules/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-shared-modules/packages/ubdcc-shared-modules/* ./
           rm -rf ubdcc-shared-modules
 
       - name: ls -l
+        shell: bash
         run: ls -l
 
       - name: Upgrade pip
@@ -74,6 +76,7 @@ jobs:
           sparse-checkout: 'packages/ubdcc-shared-modules/'
 
       - name: Move directory contents
+        shell: bash
         run: |
           mv ubdcc-shared-modules/packages/ubdcc-shared-modules/* ./
           rm -rf ubdcc-shared-modules


### PR DESCRIPTION
## Summary
Windows runner failed with:
```
rm: A parameter cannot be found that matches parameter name 'rf'.
```
because PowerShell doesn't understand Unix-style `rm -rf`. Adding `shell: bash` to the `Move directory contents` and `ls -l` steps uses Git Bash (available on all GitHub runners) for consistent behavior.

Applied to all 4 Cython package workflows.