### PR TITLE
Fix ubdcc build: rename checkout path to avoid conflict

### DIFF
--- a/.github/workflows/build_wheels_ubdcc.yml
+++ b/.github/workflows/build_wheels_ubdcc.yml
@@ -15,13 +15,13 @@ jobs:
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.ref }}
-          path: ubdcc
+          path: checkout
           sparse-checkout: 'packages/ubdcc/'
 
       - name: Move directory contents
         run: |
-          mv ubdcc/packages/ubdcc/* ./
-          rm -rf ubdcc
+          mv checkout/packages/ubdcc/* ./
+          rm -rf checkout
 
       - name: ls -l
         run: ls -l


### PR DESCRIPTION
## Summary
The ubdcc build failed with:
```
mv: cannot overwrite './ubdcc': Directory not empty
```
because the checkout path `ubdcc` conflicts with the Python package directory inside `packages/ubdcc/ubdcc/`. Rename checkout path to `checkout`.