### PR TITLE
Separate GitHub Release from PyPI build workflows

### DIFF
--- a/.github/workflows/build_wheels_ubdcc.yml
+++ b/.github/workflows/build_wheels_ubdcc.yml
@@ -47,8 +47,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write
-      discussions: write
       id-token: write
     steps:
       - name: Download Artifacts
@@ -56,22 +54,6 @@ jobs:
         with:
           name: artifact
           path: dist
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: |
-            Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/changelog.html) for further information.
-          discussion_category_name: releases
-          draft: false
-          files: |
-            dist/*.tar.gz
-            dist/*.whl
-          generate_release_notes: true
-          name: ubdcc
-          prerelease: false
-          tag_name: 0.3.1
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_wheels_ubdcc_dcn.yml
+++ b/.github/workflows/build_wheels_ubdcc_dcn.yml
@@ -94,8 +94,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write
-      discussions: write
       id-token: write
     steps:
       - name: Download Artifacts
@@ -109,22 +107,6 @@ jobs:
           mkdir -p dist_upload
           find dist -name '*.whl' -exec cp {} dist_upload/ \;
           find dist -name '*.tar.gz' -exec cp {} dist_upload/ \;
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: |
-            Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/changelog.html) for further information.
-          discussion_category_name: releases
-          draft: false
-          files: |
-            dist_upload/*.tar.gz
-            dist_upload/*.whl
-          generate_release_notes: true
-          name: ubdcc-dcn
-          prerelease: false
-          tag_name: 0.3.1
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_wheels_ubdcc_mgmt.yml
+++ b/.github/workflows/build_wheels_ubdcc_mgmt.yml
@@ -94,8 +94,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write
-      discussions: write
       id-token: write
     steps:
       - name: Download Artifacts
@@ -109,22 +107,6 @@ jobs:
           mkdir -p dist_upload
           find dist -name '*.whl' -exec cp {} dist_upload/ \;
           find dist -name '*.tar.gz' -exec cp {} dist_upload/ \;
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: |
-            Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/changelog.html) for further information.
-          discussion_category_name: releases
-          draft: false
-          files: |
-            dist_upload/*.tar.gz
-            dist_upload/*.whl
-          generate_release_notes: true
-          name: ubdcc-mgmt
-          prerelease: false
-          tag_name: 0.3.1
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_wheels_ubdcc_restapi.yml
+++ b/.github/workflows/build_wheels_ubdcc_restapi.yml
@@ -94,8 +94,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write
-      discussions: write
       id-token: write
     steps:
       - name: Download Artifacts
@@ -109,22 +107,6 @@ jobs:
           mkdir -p dist_upload
           find dist -name '*.whl' -exec cp {} dist_upload/ \;
           find dist -name '*.tar.gz' -exec cp {} dist_upload/ \;
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: |
-            Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/changelog.html) for further information.
-          discussion_category_name: releases
-          draft: false
-          files: |
-            dist_upload/*.tar.gz
-            dist_upload/*.whl
-          generate_release_notes: true
-          name: ubdcc-restapi
-          prerelease: false
-          tag_name: 0.3.1
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/build_wheels_ubdcc_shared_modules.yml
+++ b/.github/workflows/build_wheels_ubdcc_shared_modules.yml
@@ -94,8 +94,6 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
-      contents: write
-      discussions: write
       id-token: write
     steps:
       - name: Download Artifacts
@@ -109,22 +107,6 @@ jobs:
           mkdir -p dist_upload
           find dist -name '*.whl' -exec cp {} dist_upload/ \;
           find dist -name '*.tar.gz' -exec cp {} dist_upload/ \;
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          body: |
-            Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-depthcache-cluster-for-binance/changelog.html) for further information.
-          discussion_category_name: releases
-          draft: false
-          files: |
-            dist_upload/*.tar.gz
-            dist_upload/*.whl
-          generate_release_notes: true
-          name: ubdcc-shared-modules
-          prerelease: false
-          tag_name: 0.3.1
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create PyPi Release
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -1,0 +1,30 @@
+name: Create GitHub Release
+
+on:
+  workflow_dispatch:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      discussions: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v2
+      with:
+        tag_name: 0.3.1
+        name: Release 0.3.1
+        body: |
+          Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/changelog.html) for further information.
+        discussion_category_name: releases
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
A single GitHub release covers all 5 packages for a given tag. Having each build workflow create its own release fails with "Release already exists" for subsequent packages.

- Restore standalone `gh_release.yml` workflow (triggered manually once per release tag)
- Remove `Create GitHub Release` step from all 5 build workflows
- Simplify permissions to only `id-token: write` (needed for PyPI Trusted Publishing)

Release flow now:
1. Run all 5 `build_wheels_ubdcc_*.yml` workflows to publish wheels to PyPI
2. Run `gh_release.yml` once to create the GitHub release