### PR TITLE
Helm: update image registry URLs from OVH to ghcr.io

### DIFF
--- a/dev/helm/ubdcc/templates/ubdcc-dcn.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-dcn.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
         - name: {{ .Values.name.dcn }}
-          image: "i018oau9.c1.de1.container-registry.ovh.net/library/ubdcc-dcn:{{ .Chart.AppVersion }}"
+          image: "ghcr.io/oliver-zehentleitner/ubdcc-dcn:{{ .Chart.AppVersion }}"

--- a/dev/helm/ubdcc/templates/ubdcc-mgmt.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: {{ .Values.name.mgmt }}
-          image: "i018oau9.c1.de1.container-registry.ovh.net/library/ubdcc-mgmt:{{ .Chart.AppVersion }}"
+          image: "ghcr.io/oliver-zehentleitner/ubdcc-mgmt:{{ .Chart.AppVersion }}"
           ports:
             - name: rest-private
               containerPort: 8080

--- a/dev/helm/ubdcc/templates/ubdcc-restapi.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-restapi.yaml
@@ -28,7 +28,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: {{ .Values.name.restapi }}
-          image: "i018oau9.c1.de1.container-registry.ovh.net/library/ubdcc-restapi:{{ .Chart.AppVersion }}"
+          image: "ghcr.io/oliver-zehentleitner/ubdcc-restapi:{{ .Chart.AppVersion }}"
           ports:
             - name: rest-private
               containerPort: 8080


### PR DESCRIPTION
## Summary
Minimal change: update the 3 image references in Helm templates to point at ghcr.io where the new Docker images live.

- `i018oau9.c1.de1.container-registry.ovh.net/library/` → `ghcr.io/oliver-zehentleitner/`
- 3 templates affected: ubdcc-dcn, ubdcc-mgmt, ubdcc-restapi
- DaemonSet/StatefulSet structure unchanged — works exactly like before with new URLs

K8s YAMLs in `admin/k8s/` still need updating (separate PR — they pin by SHA256 digest which needs to be regenerated from the new ghcr.io images).