### PR TITLE
K8s YAMLs: migrate to ghcr.io with version tag

### DIFF
--- a/admin/k8s/ubdcc-dcn.yaml
+++ b/admin/k8s/ubdcc-dcn.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
         - name: ubdcc-dcn
-          image: i018oau9.c1.de1.container-registry.ovh.net/library/ubdcc-dcn@sha256:f7e2e1a961c9250431ee9fcb23ff4a28eaa640f1edc7ebd2f7a871e39699c2b9
+          image: ghcr.io/oliver-zehentleitner/ubdcc-dcn:0.3.3

--- a/admin/k8s/ubdcc-mgmt.yaml
+++ b/admin/k8s/ubdcc-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: ubdcc-mgmt
-          image: i018oau9.c1.de1.container-registry.ovh.net/library/ubdcc-mgmt@sha256:aa28458eb78c70be40592f835928193de14f7bf4ee8634406c5a829ab5582a75
+          image: ghcr.io/oliver-zehentleitner/ubdcc-mgmt:0.3.3
           ports:
             - name: rest-private
               containerPort: 8080

--- a/admin/k8s/ubdcc-restapi.yaml
+++ b/admin/k8s/ubdcc-restapi.yaml
@@ -28,7 +28,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: ubdcc-restapi
-          image: i018oau9.c1.de1.container-registry.ovh.net/library/ubdcc-restapi@sha256:16f2b8172ceb916bfea223cb863344500b5bc44495ab074ac18645dd7fa53729
+          image: ghcr.io/oliver-zehentleitner/ubdcc-restapi:0.3.3
           ports:
             - name: rest-private
               containerPort: 8080

--- a/dev/set_version_config.yml
+++ b/dev/set_version_config.yml
@@ -5,6 +5,9 @@ files:
 - .github/workflows/build_wheels_ubdcc_restapi.yml
 - .github/workflows/build_wheels_ubdcc_shared_modules.yml
 - .github/workflows/docker_build.yml
+- admin/k8s/ubdcc-dcn.yaml
+- admin/k8s/ubdcc-mgmt.yaml
+- admin/k8s/ubdcc-restapi.yaml
 - .github/workflows/gh_release.yml
 - container/generic_loader/requirements-ubdcc_dcn.txt
 - container/generic_loader/requirements-ubdcc_mgmt.txt


### PR DESCRIPTION
## Summary
- Replace dead OVH registry URLs with `ghcr.io/oliver-zehentleitner/`
- Use version tag (`:0.3.3`) instead of SHA256 digests — no more manual digest regeneration after every Docker build
- Add the 3 yamls to `set_version_config.yml` so `set_version.py` keeps them in sync with every release