### PR TITLE
helm_release: create docs/helm dir before cd

### DIFF
--- a/.github/workflows/helm_release.yml
+++ b/.github/workflows/helm_release.yml
@@ -20,6 +20,7 @@ jobs:
 
       - name: Package chart
         run: |
+          mkdir -p docs/helm
           cd docs/helm
           helm package ../../dev/helm/ubdcc/
           helm repo index . --url https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/helm


### PR DESCRIPTION
The directory was cleaned out and no longer exists in the repo — create it on the fly before packaging.