### PR TITLE
Remove dev/helm/release.sh

### DIFF
--- a/dev/helm/release.sh
+++ b/dev/helm/release.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-# Package the Helm chart and regenerate the repo index.
-# Run from the repo root: bash dev/helm/release.sh
-cd ./docs/helm
-helm package ../../dev/helm/ubdcc/
-helm repo index . --url https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/helm


### PR DESCRIPTION
Replaced by the helm_release GH Actions workflow — no local helm install needed anymore.