### PR TITLE
Add navigation anchor links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@
 
 # UNICORN Binance DepthCache Cluster (UBDCC)
 
+[What](#what-is-ubdcc) | [Why](#why) | [Architecture](#architecture) | [Features](#key-features) | 
+[Local Setup](#local-setup-without-kubernetes) | [REST API](#rest-api) | [Kubernetes](#kubernetes-setup) | 
+[Python Client](#accessing-from-python) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
+[Contributing](#contributing) | [Disclaimer](#disclaimer)
+
 Manage hundreds of Binance order book depth caches and access them via REST API — from any programming language, 
 any number of clients, with load balancing and automatic failover. Simple to set up: `pip install`, start three 
 processes, done.


### PR DESCRIPTION
Match the UBS README pattern (UBWA/UBLDC) with anchor links right below the H1 for quick section navigation.