### PR TITLE
Remove 'restart' subcommand from external CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ ubdcc start --dcn 4          # starts mgmt + restapi + 4 DCN in interactive shel
 
 Interactive shell commands: `status`, `add-dcn [count]`, `remove-dcn <count|name>`, `restart <name>`, `stop`, `help`.
 
-`.ubdcc` state file in CWD stores the mgmt port so `status`/`stop`/`restart` find it without `--port`.
+`.ubdcc` state file in CWD stores the mgmt port so `status`/`stop` find it without `--port`.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.3.3.dev (development stage/unreleased/unstable)
+### Removed
+- External `ubdcc restart <name>` CLI subcommand — it didn'''t actually work because the spawn functions live in the interactive shell closure. Restart is still available inside the interactive `ubdcc>` shell.
 
 ## 0.3.3
 ### Added

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ While the cluster is running, you can also manage it from another terminal:
 ```bash
 ubdcc status                     # show cluster status
 ubdcc stop                       # shut down the cluster
-ubdcc restart g3HcyluSZ5qWarm   # restart a specific pod
 ```
 
 The CLI automatically remembers the mgmt port. If you started with a custom port (`ubdcc start --port 42090`), 

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.3.0.dev (development stage/unreleased/unstable)
+### Removed
+- External `ubdcc restart <name>` CLI subcommand — only worked inside the interactive shell. The shell command is unchanged.
 
 ## 0.3.0
 ### Added

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -303,11 +303,6 @@ def cmd_stop(args):
     shutdown_all(mgmt_port)
 
 
-def cmd_restart(args):
-    mgmt_port = get_mgmt_port(args)
-    restart_pod(mgmt_port, args.name)
-
-
 def remove_dcn_by_count(mgmt_port, count, processes):
     """Stop N DCN pods."""
     url = f"http://127.0.0.1:{mgmt_port}/get_cluster_info"
@@ -511,11 +506,6 @@ def main():
     stop_parser = subparsers.add_parser('stop', help='Stop the cluster')
     stop_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
 
-    # restart
-    restart_parser = subparsers.add_parser('restart', help='Restart a specific pod')
-    restart_parser.add_argument('name', help='Pod name or UID to restart')
-    restart_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
-
     args = parser.parse_args()
 
     if args.command == 'start':
@@ -524,8 +514,6 @@ def main():
         cmd_status(args)
     elif args.command == 'stop':
         cmd_stop(args)
-    elif args.command == 'restart':
-        cmd_restart(args)
     else:
         parser.print_help()
 


### PR DESCRIPTION
`ubdcc restart <name>` from a separate terminal doesn't work — spawn functions live in the interactive shell closure. Remove the external subcommand; it stays available inside `ubdcc start`'s interactive shell.