### PR TITLE
README intro: combine into one code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@
 [Contributing](#contributing) | [Disclaimer](#disclaimer)
 
 Manage hundreds of Binance order book depth caches and access them via REST API — from any programming language, 
-any number of clients, with load balancing and automatic failover. Simple to set up: `pip install ubdcc`, then 
-`ubdcc start`, done.
+any number of clients, with load balancing and automatic failover. Simple to set up:
+
+```bash
+pip install ubdcc
+ubdcc start
+```
 
 Built on [UNICORN Binance Local Depth Cache (UBLDC)](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache). 
 Part of the [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).


### PR DESCRIPTION
Two commands as a single bash code block — easier to copy-paste than inline backticks.