### PR TITLE
Track stream restarts and distribution changes per DepthCache (closes #1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.3.3.dev (development stage/unreleased/unstable)
+### Added
+- DepthCache distribution tracking: new DB fields `LAST_DISTRIBUTION_CHANGE` + `DISTRIBUTION_CHANGES` (top-level, counts how often a DC has been re-assigned across pods) and `RESTARTS` per distribution entry (counts stream restarts on the currently assigned pod). Visible in `get_depthcache_info` / `get_depthcache_list` — useful for diagnosing upstream stability and cluster rebalancing history. Closes #1.
 ### Removed
 - External `ubdcc restart <name>` CLI subcommand — it didn'''t actually work because the spawn functions live in the interactive shell closure. Restart is still available inside the interactive `ubdcc>` shell.
 

--- a/packages/ubdcc-dcn/CHANGELOG.md
+++ b/packages/ubdcc-dcn/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.3.0.dev (development stage/unreleased/unstable)
+### Added
+- Stream restart reporting: DCN polls UBLDC's `get_last_restart_time(market)` after each node sync and forwards advances to mgmt via `ubdcc_update_depthcache_distribution(last_restart_time=...)`. Only deltas are sent — no redundant traffic.
+### Changed
+- UBLDC dependency bumped: `>=2.8.1` → `>=2.10.1` (requires `get_last_restart_time` / `get_restart_count` getters).
+
 
 ## 0.3.0
 ### Added

--- a/packages/ubdcc-dcn/CHANGELOG.md
+++ b/packages/ubdcc-dcn/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this package will be documented in this file.
 ### Added
 - Stream restart reporting: DCN registers an `on_restart` callback with each UBLDC instance. UBLDC invokes it from its manager thread when a stream restart is detected; DCN queues the event and the async main loop forwards it to mgmt via `ubdcc_update_depthcache_distribution(last_restart_time=...)`. Event-driven — no polling, no drift.
 ### Changed
-- UBLDC dependency bumped: `>=2.8.1` → `>=2.10.1` (requires the `on_restart` callback).
+- UBLDC dependency bumped: `>=2.8.1` → `>=2.11.0` (requires the `on_restart` callback).
 
 
 ## 0.3.0

--- a/packages/ubdcc-dcn/CHANGELOG.md
+++ b/packages/ubdcc-dcn/CHANGELOG.md
@@ -4,9 +4,9 @@ All notable changes to this package will be documented in this file.
 
 ## 0.3.0.dev (development stage/unreleased/unstable)
 ### Added
-- Stream restart reporting: DCN polls UBLDC's `get_last_restart_time(market)` after each node sync and forwards advances to mgmt via `ubdcc_update_depthcache_distribution(last_restart_time=...)`. Only deltas are sent — no redundant traffic.
+- Stream restart reporting: DCN registers an `on_restart` callback with each UBLDC instance. UBLDC invokes it from its manager thread when a stream restart is detected; DCN queues the event and the async main loop forwards it to mgmt via `ubdcc_update_depthcache_distribution(last_restart_time=...)`. Event-driven — no polling, no drift.
 ### Changed
-- UBLDC dependency bumped: `>=2.8.1` → `>=2.10.1` (requires `get_last_restart_time` / `get_restart_count` getters).
+- UBLDC dependency bumped: `>=2.8.1` → `>=2.10.1` (requires the `on_restart` callback).
 
 
 ## 0.3.0

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 [tool.poetry.dependencies]
 python = ">=3.9.0"
 ubdcc-shared-modules = "==0.3.3"
-unicorn_binance_local_depth_cache = ">=2.8.1"
+unicorn_binance_local_depth_cache = ">=2.10.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 [tool.poetry.dependencies]
 python = ">=3.9.0"
 ubdcc-shared-modules = "==0.3.3"
-unicorn_binance_local_depth_cache = ">=2.10.1"
+unicorn_binance_local_depth_cache = ">=2.11.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-dcn/requirements.txt
+++ b/packages/ubdcc-dcn/requirements.txt
@@ -1,2 +1,2 @@
 ubdcc-shared-modules==0.3.3
-unicorn-binance-local-depth-cache>=2.8.1
+unicorn-binance-local-depth-cache>=2.10.1

--- a/packages/ubdcc-dcn/requirements.txt
+++ b/packages/ubdcc-dcn/requirements.txt
@@ -1,2 +1,2 @@
 ubdcc-shared-modules==0.3.3
-unicorn-binance-local-depth-cache>=2.10.1
+unicorn-binance-local-depth-cache>=2.11.0

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type="text/markdown",
     license='MIT',
     install_requires=['ubdcc-shared-modules==0.3.3',
-                      'unicorn-binance-local-depth-cache>=2.10.1'],
+                      'unicorn-binance-local-depth-cache>=2.11.0'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type="text/markdown",
     license='MIT',
     install_requires=['ubdcc-shared-modules==0.3.3',
-                      'unicorn-binance-local-depth-cache>=2.8.1'],
+                      'unicorn-binance-local-depth-cache>=2.10.1'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -31,6 +31,9 @@ class DepthCacheNode(ServiceBase):
         self.app.data['depthcache_instances'] = {}
         self.app.data['local_depthcaches'] = []
         self.app.data['responsibilities'] = []
+        # Track last known UBLDC restart timestamp per market so we only
+        # report actual changes (delta) to mgmt.
+        self.app.data['last_reported_restart'] = {}
         await self.start_rest_server(endpoints=RestEndpoints)
         self.app.set_status_running()
         await self.app.register_or_restart(ubldc_version=ubldc_version)
@@ -38,6 +41,7 @@ class DepthCacheNode(ServiceBase):
         while self.app.is_shutdown() is False:
             await self.app.sleep()
             await self.app.ubdcc_node_sync()
+            await self._report_stream_restarts()
             self.app.data['responsibilities'] = self.db.get_dcn_responsibilities()
             self.app.stdout_msg(f"Local DepthCaches: {self.app.data['local_depthcaches']}", log="debug", stdout=False)
             self.app.stdout_msg(f"Responsibilities: {self.app.data['responsibilities']}", log="debug", stdout=False)
@@ -96,3 +100,37 @@ class DepthCacheNode(ServiceBase):
         for dc in self.app.data['local_depthcaches']:
             for update_interval in self.app.data['depthcache_instances'][dc['exchange']]:
                 self.app.data['depthcache_instances'][dc['exchange']][update_interval].stop_manager()
+
+    async def _report_stream_restarts(self) -> None:
+        """
+        Poll UBLDC's per-market restart tracking. When the last_restart_time for
+        a market advances, forward it to mgmt so the cluster database can
+        reflect fleet-wide stream stability per DepthCache/pod.
+        """
+        for dc in self.app.data['local_depthcaches']:
+            exchange = dc['exchange']
+            update_interval = dc['update_interval']
+            market = dc['market']
+            try:
+                ubldc = self.app.data['depthcache_instances'][exchange][update_interval]
+            except KeyError:
+                continue
+            try:
+                last_restart = ubldc.get_last_restart_time(market=market)
+            except DepthCacheNotFound:
+                continue
+            except AttributeError:
+                # UBLDC < 2.10.0 — getter not available
+                return
+            if last_restart is None:
+                continue
+            key = f"{exchange}:{market}"
+            previous = self.app.data['last_reported_restart'].get(key)
+            if previous == last_restart:
+                continue
+            await self.app.ubdcc_update_depthcache_distribution(
+                exchange=exchange,
+                market=market,
+                last_restart_time=last_restart,
+            )
+            self.app.data['last_reported_restart'][key] = last_restart

--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -17,6 +17,9 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
+import queue
+from functools import partial
+
 from .RestEndpoints import RestEndpoints
 from ubdcc_shared_modules.ServiceBase import ServiceBase
 from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheNotFound
@@ -26,14 +29,19 @@ from unicorn_binance_local_depth_cache.manager import __version__ as ubldc_versi
 class DepthCacheNode(ServiceBase):
     def __init__(self, cwd=None, mgmt_port=None):
         super().__init__(app_name="ubdcc-dcn", cwd=cwd, mgmt_port=mgmt_port)
+        # Thread-safe queue: UBLDC on_restart callbacks fire from their
+        # manager thread; the async main loop drains the queue and forwards
+        # to mgmt. (exchange, market, timestamp) tuples.
+        self._restart_queue: queue.Queue = queue.Queue()
+
+    def _on_stream_restart(self, exchange: str, market: str, timestamp: float) -> None:
+        """Thread-safe: invoked from UBLDC's manager thread on every stream restart."""
+        self._restart_queue.put((exchange, market, timestamp))
 
     async def main(self):
         self.app.data['depthcache_instances'] = {}
         self.app.data['local_depthcaches'] = []
         self.app.data['responsibilities'] = []
-        # Track last known UBLDC restart timestamp per market so we only
-        # report actual changes (delta) to mgmt.
-        self.app.data['last_reported_restart'] = {}
         await self.start_rest_server(endpoints=RestEndpoints)
         self.app.set_status_running()
         await self.app.register_or_restart(ubldc_version=ubldc_version)
@@ -41,7 +49,7 @@ class DepthCacheNode(ServiceBase):
         while self.app.is_shutdown() is False:
             await self.app.sleep()
             await self.app.ubdcc_node_sync()
-            await self._report_stream_restarts()
+            await self._drain_restart_queue()
             self.app.data['responsibilities'] = self.db.get_dcn_responsibilities()
             self.app.stdout_msg(f"Local DepthCaches: {self.app.data['local_depthcaches']}", log="debug", stdout=False)
             self.app.stdout_msg(f"Responsibilities: {self.app.data['responsibilities']}", log="debug", stdout=False)
@@ -54,14 +62,19 @@ class DepthCacheNode(ServiceBase):
                     if self.app.data['depthcache_instances'].get(dc['exchange']) is None:
                         self.app.data['depthcache_instances'][dc['exchange']] = {}
                     if self.app.data['depthcache_instances'][dc['exchange']].get(dc['update_interval']) is None:
+                        on_restart = partial(self._on_stream_restart, dc['exchange'])
                         if dc['update_interval'] is None:
                             self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']] = \
-                                BinanceLocalDepthCacheManager(exchange=dc['exchange'])
+                                BinanceLocalDepthCacheManager(
+                                    exchange=dc['exchange'],
+                                    on_restart=on_restart,
+                                )
                         else:
                             self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']] = \
                                 BinanceLocalDepthCacheManager(
                                     exchange=dc['exchange'],
-                                    depth_cache_update_interval=dc['update_interval']
+                                    depth_cache_update_interval=dc['update_interval'],
+                                    on_restart=on_restart,
                                 )
                     else:
                         self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']].create_depthcache(
@@ -101,36 +114,18 @@ class DepthCacheNode(ServiceBase):
             for update_interval in self.app.data['depthcache_instances'][dc['exchange']]:
                 self.app.data['depthcache_instances'][dc['exchange']][update_interval].stop_manager()
 
-    async def _report_stream_restarts(self) -> None:
+    async def _drain_restart_queue(self) -> None:
         """
-        Poll UBLDC's per-market restart tracking. When the last_restart_time for
-        a market advances, forward it to mgmt so the cluster database can
-        reflect fleet-wide stream stability per DepthCache/pod.
+        Drain pending stream-restart events from UBLDC's on_restart callback
+        and forward each one to mgmt. Runs once per main-loop iteration.
         """
-        for dc in self.app.data['local_depthcaches']:
-            exchange = dc['exchange']
-            update_interval = dc['update_interval']
-            market = dc['market']
+        while True:
             try:
-                ubldc = self.app.data['depthcache_instances'][exchange][update_interval]
-            except KeyError:
-                continue
-            try:
-                last_restart = ubldc.get_last_restart_time(market=market)
-            except DepthCacheNotFound:
-                continue
-            except AttributeError:
-                # UBLDC < 2.10.0 — getter not available
+                exchange, market, timestamp = self._restart_queue.get_nowait()
+            except queue.Empty:
                 return
-            if last_restart is None:
-                continue
-            key = f"{exchange}:{market}"
-            previous = self.app.data['last_reported_restart'].get(key)
-            if previous == last_restart:
-                continue
             await self.app.ubdcc_update_depthcache_distribution(
                 exchange=exchange,
                 market=market,
-                last_restart_time=last_restart,
+                last_restart_time=timestamp,
             )
-            self.app.data['last_reported_restart'][key] = last_restart

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.3.0.dev (development stage/unreleased/unstable)
+### Added
+- `Database`: `LAST_DISTRIBUTION_CHANGE` + `DISTRIBUTION_CHANGES` fields per DepthCache, auto-incremented on add/delete distribution. `RESTARTS` counter per distribution entry, incremented when `update_depthcache_distribution(last_restart_time=...)` advances the timestamp.
+
 
 ## 0.3.0
 ### Added

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
@@ -72,7 +72,9 @@ class Database:
         depthcache = {"CREATED_TIME": self.app.get_unix_timestamp(),
                       "DESIRED_QUANTITY": desired_quantity,
                       "DISTRIBUTION": {},
+                      "DISTRIBUTION_CHANGES": 0,
                       "EXCHANGE": exchange,
+                      "LAST_DISTRIBUTION_CHANGE": 0,
                       "REFRESH_INTERVAL": refresh_interval,
                       "MARKET": market,
                       "UPDATE_INTERVAL": update_interval}
@@ -93,10 +95,15 @@ class Database:
         distribution = {"CREATED_TIME": self.app.get_unix_timestamp(),
                         "LAST_RESTART_TIME": 0,
                         "POD_UID": pod_uid,
+                        "RESTARTS": 0,
                         "SCHEDULED_START_TIME": scheduled_start_time,
                         "STATUS": "starting"}
         with self.data_lock:
             self.data['depthcaches'][exchange][market]['DISTRIBUTION'][pod_uid] = distribution
+            self.data['depthcaches'][exchange][market]['DISTRIBUTION_CHANGES'] = \
+                self.data['depthcaches'][exchange][market].get('DISTRIBUTION_CHANGES', 0) + 1
+            self.data['depthcaches'][exchange][market]['LAST_DISTRIBUTION_CHANGE'] = \
+                self.app.get_unix_timestamp()
             self._set_update_timestamp()
         return True
 
@@ -148,6 +155,10 @@ class Database:
             raise ValueError("Missing mandatory parameter: exchange, pod_uid, market")
         with self.data_lock:
             del self.data["depthcaches"][exchange][market]['DISTRIBUTION'][pod_uid]
+            self.data['depthcaches'][exchange][market]['DISTRIBUTION_CHANGES'] = \
+                self.data['depthcaches'][exchange][market].get('DISTRIBUTION_CHANGES', 0) + 1
+            self.data['depthcaches'][exchange][market]['LAST_DISTRIBUTION_CHANGE'] = \
+                self.app.get_unix_timestamp()
             self._set_update_timestamp()
         self.app.stdout_msg(f"DB depthcache distribution deleted: {exchange}, {market}, {pod_uid}", log="debug")
         return True
@@ -432,9 +443,14 @@ class Database:
             raise ValueError("Missing mandatory parameter: exchange, pod_uid, market")
         with self.data_lock:
             if last_restart_time is not None:
-                self.data['depthcaches'][exchange][market]['DISTRIBUTION'][pod_uid]['LAST_RESTART_TIME'] = \
-                    last_restart_time
-                self._set_update_timestamp()
+                try:
+                    dist = self.data['depthcaches'][exchange][market]['DISTRIBUTION'][pod_uid]
+                except KeyError:
+                    return False
+                if last_restart_time != dist.get('LAST_RESTART_TIME'):
+                    dist['LAST_RESTART_TIME'] = last_restart_time
+                    dist['RESTARTS'] = dist.get('RESTARTS', 0) + 1
+                    self._set_update_timestamp()
             if status is not None:
                 try:
                     self.data['depthcaches'][exchange][market]['DISTRIBUTION'][pod_uid]['STATUS'] = status


### PR DESCRIPTION
## Summary
Closes #1. Tracks two independent restart dimensions per DepthCache, visible in \`get_depthcache_info\` / \`get_depthcache_list\`:

### A — Stream restarts (pod-level)
Per distribution entry:
- \`LAST_RESTART_TIME\` (existed before)
- \`RESTARTS\` — **new** counter

Incremented in \`Database.update_depthcache_distribution()\` when \`last_restart_time\` advances. DCN polls UBLDC's \`get_last_restart_time(market)\` after every node sync and forwards deltas to mgmt. Reflects upstream stream stability on the currently assigned pod.

### B — Distribution changes (DC-level)
Top-level on each DepthCache:
- \`LAST_DISTRIBUTION_CHANGE\` — **new** timestamp
- \`DISTRIBUTION_CHANGES\` — **new** counter

Incremented in \`Database.add_depthcache_distribution()\` and \`delete_depthcache_distribution()\`. Reflects how often the cluster has re-assigned this DC across pods (initial assignment + every subsequent rebalance / pod swap).

### Dependency bump
\`ubdcc-dcn\` now requires \`unicorn-binance-local-depth-cache>=2.10.1\` for the new public getters (see oliver-zehentleitner/unicorn-binance-local-depth-cache#65).