### PR TITLE
Emit error/error_id on failover success (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 ## 0.3.3.dev (development stage/unreleased/unstable)
 ### Added
+- `get_asks` / `get_bids`: when failover recovers from one or more unreachable DCNs, the successful response now includes an `error_id` (`#5001`) and an `error` message listing the pods that failed before success. Gives monitoring a visible signal that failover occurred without changing the OK-with-data semantics. Closes #3.
+### Added
 - DepthCache distribution tracking: new DB fields `LAST_DISTRIBUTION_CHANGE` + `DISTRIBUTION_CHANGES` (top-level, counts how often a DC has been re-assigned across pods) and `RESTARTS` per distribution entry (counts stream restarts on the currently assigned pod). Visible in `get_depthcache_info` / `get_depthcache_list` — useful for diagnosing upstream stability and cluster rebalancing history. Closes #1.
 ### Removed
 - External `ubdcc restart <name>` CLI subcommand — it didn'''t actually work because the spawn functions live in the interactive shell closure. Restart is still available inside the interactive `ubdcc>` shell.

--- a/packages/ubdcc-restapi/CHANGELOG.md
+++ b/packages/ubdcc-restapi/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.3.0.dev (development stage/unreleased/unstable)
+### Added
+- Failover visibility: when `/get_asks` or `/get_bids` recovers from one or more DCN failures, the response stays `result: OK` with data as before, but additionally carries `error_id: "#5001"` and an `error` string listing the failed pods. Gives clients a monitoring hook for partial-failure events.
+
 
 ## 0.3.0
 ### Added

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -96,6 +96,7 @@ class RestEndpoints(RestEndpointsBase):
                  f"limit_count={limit_count}&"
                  f"threshold_volume={threshold_volume}")
         result_errors = []
+        failover_errors = []
         first_choice_dcn = self.app.get_dcn_uid_unused_longest_time(selection=[address[2] for address in addresses])
         for i, address in enumerate(addresses):
             if address[2] == first_choice_dcn:
@@ -110,8 +111,18 @@ class RestEndpoints(RestEndpointsBase):
                     used_pods.append([pod.get('NAME'), pod.get('UID')])
                     result['debug'] = self.create_debug_response(process_start_time=process_start_time,
                                                                  url=request_url, used_pods=used_pods)
+                if failover_errors:
+                    result['error_id'] = "#5001"
+                    result['error'] = (
+                        f"Data served after {len(failover_errors)} DCN failure(s): "
+                        + "; ".join(failover_errors)
+                    )
                 return result
             result_errors.append([address, port, str(result)])
+            pod = self.app.data['db'].get_pod_by_address(address=address)
+            pod_name = pod.get('NAME') if pod else address
+            err_detail = result.get('error') or result.get('message') or str(result)
+            failover_errors.append(f"pod={pod_name} ({err_detail})")
         self.app.stdout_msg(f"No DCN has responded to the request: {result_errors}")
         return self.get_error_response(event=event, error_id="#5000", message=f"No DCN has responded to the request!",
                                        params={"requests": result_errors}, process_start_time=process_start_time,

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -120,9 +120,12 @@ class RestEndpoints(RestEndpointsBase):
                 return result
             result_errors.append([address, port, str(result)])
             pod = self.app.data['db'].get_pod_by_address(address=address)
-            pod_name = pod.get('NAME') if pod else address
+            if pod:
+                pod_ref = f"pod={pod.get('NAME')} (uid={pod.get('UID')})"
+            else:
+                pod_ref = f"pod={address}:{port}"
             err_detail = result.get('error') or result.get('message') or str(result)
-            failover_errors.append(f"pod={pod_name} ({err_detail})")
+            failover_errors.append(f"{pod_ref} — {err_detail}")
         self.app.stdout_msg(f"No DCN has responded to the request: {result_errors}")
         return self.get_error_response(event=event, error_id="#5000", message=f"No DCN has responded to the request!",
                                        params={"requests": result_errors}, process_start_time=process_start_time,

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.3.0.dev (development stage/unreleased/unstable)
+### Changed
+- `get_ok_response()` now accepts optional `error` and `error_id` parameters, matching the existing error-response convention. Enables OK-with-warnings responses (e.g. failover success in restapi).
+
 ### Added
 - `Database`: `LAST_DISTRIBUTION_CHANGE` + `DISTRIBUTION_CHANGES` fields per DepthCache, auto-incremented on add/delete distribution. `RESTARTS` counter per distribution entry, incremented when `update_depthcache_distribution(last_restart_time=...)` advances the timestamp.
 

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
@@ -88,10 +88,15 @@ class RestEndpointsBase:
         return JSONResponse(status_code=200, content=response_sorted)
 
     def get_ok_response(self, event: str = None, params: dict = None, process_start_time: float = None,
-                        url: str = None, post_body: dict = None, used_pods: list = None):
+                        url: str = None, post_body: dict = None, used_pods: list = None,
+                        error: str = None, error_id: str = None):
         response = {"event": event, "result": "OK"}
         if params:
             response.update(params)
+        if error is not None:
+            response['error'] = error
+        if error_id is not None:
+            response['error_id'] = error_id
         if process_start_time is not None:
             response['debug'] = self.create_debug_response(process_start_time=process_start_time,
                                                            url=url, post_body=post_body,


### PR DESCRIPTION
## Summary
Closes #3. When restapi's \`/get_asks\` or \`/get_bids\` recovers from one or more DCN failures via failover, the successful response now surfaces the failure information for monitoring.

### Before
First DCN times out → restapi silently retries next DCN → returns data. Client sees nothing about the failed attempt.

### After
First DCN times out → restapi retries → returns data **with** \`error_id: "#5001"\` and \`error: "Data served after 1 DCN failure(s): pod=abc-xyz (aiohttp.ClientError - timeout)"\`.

### Design
- Reuses existing \`error\` / \`error_id\` convention (matches error-response shape)
- \`result\` stays \`"OK"\` — data is present, semantics unchanged
- Only appears when failover actually happened (no noise for first-try successes)
- Applies only to \`/get_asks\` and \`/get_bids\` (the failover-capable endpoints); \`create_*\`/\`stop_*\` go directly to mgmt and have no failover path

### Helper change
\`get_ok_response()\` in \`RestEndpointsBase\` now accepts optional \`error\` and \`error_id\` kwargs.