### PR TITLE
Add Binance API credentials support (account-grouped, load-balanced)

### DIFF
--- a/.github/workflows/docker_build.yml
+++ b/.github/workflows/docker_build.yml
@@ -7,7 +7,7 @@ on:
         description: 'Version tag (must match an existing PyPI release)'
         required: true
         type: string
-        default: '0.3.3'
+        default: '0.4.0.dev'
 
 jobs:
   build:

--- a/.github/workflows/gh_release.yml
+++ b/.github/workflows/gh_release.yml
@@ -19,8 +19,8 @@ jobs:
     - name: Create GitHub Release
       uses: softprops/action-gh-release@v2
       with:
-        tag_name: 0.3.3
-        name: Release 0.3.3
+        tag_name: 0.4.0.dev
+        name: Release 0.4.0.dev
         body: |
           Please read the [CHANGELOG](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/changelog.html) for further information.
         discussion_category_name: releases

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
 Distributed microservice cluster (MIT License) that manages multiple local Binance order book depth caches. Runs on Kubernetes OR locally via `pip install ubdcc`. Clients interact via a public REST API — no local Binance connection required on the client side.
 
 **Abbreviation:** UBDCC
-**Current Version:** 0.3.3
+**Current Version:** 0.4.0.dev
 **Author:** Oliver Zehentleitner
 **Python:** 3.9-3.14 on Linux, macOS, Windows
 **Runtime:** Kubernetes, Docker, or local processes
@@ -130,7 +130,7 @@ Interactive shell commands: `status`, `add-dcn [count]`, `remove-dcn <count|name
 
 - `dev/set_version.py <new_version>` — updates the version across all listed files
 - Config: `dev/set_version_config.yml`
-- Current version: `0.3.3`
+- Current version: `0.4.0.dev`
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.3.3.dev (development stage/unreleased/unstable)
+## 0.4.0.dev (development stage/unreleased/unstable)
 ### Added
+- Binance API credentials support. Optional: add one or more `(api_key, api_secret)` pairs per account group (`binance.com`, `binance.com-testnet`, `binance.com-futures-testnet`, `binance.us`, `binance.tr`) via new REST endpoints `/ubdcc_add_credentials` (POST/GET), `/ubdcc_remove_credentials`, `/ubdcc_get_credentials_list` and matching `ubdcc credentials add/list/remove` CLI subcommands. Mgmt load-balances credentials across DCN pods (fewest-assigned-first); DCNs fetch their assigned key via the internal `/ubdcc_assign_credentials` endpoint and pass it to UBLDC as a `BinanceRestApiManager`. Lets the cluster use authenticated rate limits without mandating credentials — public-only operation remains unchanged. Keys are part of the self-healing DB sync (full cleartext cluster-internal); public responses only show masked previews and the list of assigned DCN UIDs per key. See README → API Credentials for the security trade-offs.
 - `get_asks` / `get_bids`: when failover recovers from one or more unreachable DCNs, the successful response now includes an `error_id` (`#5001`) and an `error` message listing the pods that failed before success. Gives monitoring a visible signal that failover occurred without changing the OK-with-data semantics. Closes #3.
-### Added
 - DepthCache distribution tracking: new DB fields `LAST_DISTRIBUTION_CHANGE` + `DISTRIBUTION_CHANGES` (top-level, counts how often a DC has been re-assigned across pods) and `RESTARTS` per distribution entry (counts stream restarts on the currently assigned pod). Visible in `get_depthcache_info` / `get_depthcache_list` — useful for diagnosing upstream stability and cluster rebalancing history. Closes #1.
 ### Removed
 - External `ubdcc restart <name>` CLI subcommand — it didn'''t actually work because the spawn functions live in the interactive shell closure. Restart is still available inside the interactive `ubdcc>` shell.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [What](#what-is-ubdcc) | [Architecture](#architecture) | [Features](#key-features) | 
 [Local Setup](#local-setup-without-kubernetes) | [REST API](#rest-api) | [Kubernetes](#kubernetes-setup) | 
-[Python Client](#accessing-from-python) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
+[API Credentials](#api-credentials) | [Python Client](#accessing-from-python) | [Bugs](#how-to-report-bugs-or-suggest-improvements) | 
 [Contributing](#contributing) | [Disclaimer](#disclaimer)
 
 Manage hundreds of Binance order book depth caches and access them via REST API — from any programming language, 
@@ -153,7 +153,7 @@ ubdcc start --dcn 4
 This starts 1 mgmt + 1 restapi + 4 DCN processes and drops you into an interactive console:
 
 ```
-UBDCC Cluster Manager v0.3.3
+UBDCC Cluster Manager v0.4.0.dev
 Starting cluster with mgmt port 42080, 4 DCN(s)...
   mgmt started (PID 12345)
   restapi started (PID 12346)
@@ -167,15 +167,15 @@ Cluster is ready!
 
 ROLE             NAME                 PORT     STATUS     VERSION
 ----------------------------------------------------------------------
-ubdcc-mgmt       ubdcc-mgmt           42080    running    0.3.3
-ubdcc-restapi    TDMKiCnT6jZ39N       42081    running    0.3.3
-ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.3.3
-ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.3.3
-ubdcc-dcn        tDuu9mOXrt445XU      42084    running    0.3.3
-ubdcc-dcn        xg6RZRf1APErfh1      42085    running    0.3.3
+ubdcc-mgmt       ubdcc-mgmt           42080    running    0.4.0.dev
+ubdcc-restapi    TDMKiCnT6jZ39N       42081    running    0.4.0.dev
+ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.4.0.dev
+ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.4.0.dev
+ubdcc-dcn        tDuu9mOXrt445XU      42084    running    0.4.0.dev
+ubdcc-dcn        xg6RZRf1APErfh1      42085    running    0.4.0.dev
 
 DepthCaches: 0
-Version: 0.3.3
+Version: 0.4.0.dev
 
 REST API: http://127.0.0.1:42081/
 Cluster info: http://127.0.0.1:42081/get_cluster_info
@@ -263,6 +263,9 @@ These are the endpoints you use to interact with the cluster. All requests go th
 | `/get_depthcache_list` | GET | — | List all DepthCaches with status and distribution |
 | `/get_depthcache_info` | GET | `exchange`, `market` | Detailed info for a specific DepthCache |
 | `/stop_depthcache` | GET | `exchange`, `market` | Stop and remove a DepthCache |
+| `/ubdcc_add_credentials` | POST/GET | `account_group`, `api_key`, `api_secret` | Store a Binance API key (see [API Credentials](#api-credentials)) |
+| `/ubdcc_remove_credentials` | POST/GET | `id` | Delete a stored API key |
+| `/ubdcc_get_credentials_list` | GET | — | List stored keys (masked) with their assigned DCNs |
 
 All public endpoints accept `debug=true` as an additional parameter for timing and routing details.
 
@@ -280,6 +283,7 @@ understanding them helps when debugging or extending the system.
 | `/ubdcc_node_sync` | GET | Periodic heartbeat — DCN/restapi reports status, mgmt pushes DB backup back |
 | `/ubdcc_get_responsible_dcn_addresses` | GET | Returns which DCN holds a specific DepthCache (used by restapi for routing) |
 | `/ubdcc_update_depthcache_distribution` | GET | DCN reports DepthCache status changes (starting, running) |
+| `/ubdcc_assign_credentials` | GET | DCN requests an API key for a given `account_group` — load-balanced across available keys |
 
 **All pods** (shared base):
 
@@ -394,7 +398,7 @@ helm search repo ubdcc
 - Then
 
 ``` 
-helm install ubdcc ubdcc/ubdcc --version 0.3.3
+helm install ubdcc ubdcc/ubdcc --version 0.4.0.dev
 ```
 
 #### Choose a namespace
@@ -427,6 +431,66 @@ kubectl apply -f ./ubdcc-dcn.yaml
 ```
 kubectl describe services ubdcc-restapi
 ```
+
+## API Credentials
+
+UBDCC can run entirely **without** Binance API keys — DepthCaches are built from public market data
+streams and endpoints. When you run at larger scale you may want to add API keys to raise the REST
+rate-limit ceiling (snapshots for initial sync, refresh cycles). Keys are optional.
+
+### Account groups
+
+Each Binance account has its own keys. UBDCC groups related exchanges under one `account_group`:
+
+| account_group                   | Covers UBLDC exchanges                                                                                       |
+|---------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `binance.com`                   | `binance.com`, `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`                    |
+| `binance.com-testnet`           | `binance.com-testnet` (Spot testnet — separate login on testnet.binance.vision)                              |
+| `binance.com-futures-testnet`   | `binance.com-futures-testnet` (Futures testnet — separate login on testnet.binancefuture.com)                |
+| `binance.us`                    | `binance.us`                                                                                                 |
+| `binance.tr`                    | `trbinance.com`                                                                                              |
+
+### Add / remove / list
+
+```bash
+# Add a key
+ubdcc credentials add --account-group binance.com --api-key <KEY> --api-secret <SECRET>
+
+# List (masked)
+ubdcc credentials list
+
+# Remove
+ubdcc credentials remove <id>
+```
+
+Or over HTTP:
+
+```bash
+curl -X POST 'http://127.0.0.1:42081/ubdcc_add_credentials' \
+  -H 'Content-Type: application/json' \
+  -d '{"account_group":"binance.com","api_key":"...","api_secret":"..."}'
+```
+
+You can register **multiple key pairs per account group**. Mgmt assigns each DCN one key from the
+pool (load-balanced: the key with the fewest assigned DCNs wins). Restart the DCN to pick up a new
+assignment. `get_cluster_info` / `credentials list` show which DCNs each key is assigned to.
+
+### Security caveats
+
+- **Keys are stored in the cluster DB** (the same DB that is replicated to every pod for
+  self-healing). Inside the cluster they are full, cleartext — this is a deliberate trade-off so
+  that the self-healing/backup flow keeps working.
+- Public responses (`get_cluster_info`, `ubdcc_get_credentials_list`) only return **masked
+  previews** of the key and never the secret. Only the internal `/ubdcc_assign_credentials`
+  endpoint returns the full pair, and only to a requesting DCN.
+- It is **your responsibility** to protect the cluster: lock down the network (firewall, private
+  VPC), restrict who can talk to mgmt/restapi, keep node images/backups safe. UBDCC does not yet
+  provide transport encryption or authentication on the internal API — we are building from the
+  core outward.
+- If you don't want to take on that risk, run UBDCC without credentials — everything still works,
+  just with Binance's public rate limits.
+- Give each Binance API key the **minimum** permissions it needs. For DepthCache use, read-only is
+  sufficient. IP-whitelist the key on Binance if you can.
 
 ## Security
 In any case, you should set the firewall in the web interface of the Kubernetes provider so that only your systems 

--- a/TASKS.md
+++ b/TASKS.md
@@ -32,11 +32,16 @@ Open development tasks, ideas, and decisions.
 - No test coverage beyond placeholder exists
 - Start with mocked unit tests for `Database.py` and `App.py` logic
 
-### [ ] Binance API Key support per DCN
-- Currently all DCNs fetch order book snapshots without authentication (public rate limits)
-- With API keys: higher rate limits → faster initialization with many DepthCaches
-- Could pass api_key/api_secret per DCN or cluster-wide via CLI/config
-- UBLDC already supports api_key/api_secret in BinanceLocalDepthCacheManager
+### [ ] Secure the internal mgmt↔DCN API
+- Current state (0.4.0): API credentials live in the cluster DB in cleartext and
+  are served to DCNs over plain HTTP on the internal API. Mitigated only by
+  network isolation (user's responsibility, documented in README).
+- Next layers to consider (from innermost outward):
+  - Mutual authentication between pods (shared cluster secret or mTLS)
+  - Signed/encrypted credential transport on `/ubdcc_assign_credentials`
+  - At-rest encryption for credentials in the DB backup
+  - Optional credential storage backend (env var, file, K8s secret, vault)
+- Design needs its own round — don't bolt on ad-hoc.
 
 ### [ ] Audit and fix all silent except/pass blocks
 - Suite-wide initiative — same task tracked in all unicorn-* repos

--- a/admin/k8s/ubdcc-dcn.yaml
+++ b/admin/k8s/ubdcc-dcn.yaml
@@ -14,4 +14,4 @@ spec:
     spec:
       containers:
         - name: ubdcc-dcn
-          image: ghcr.io/oliver-zehentleitner/ubdcc-dcn:0.3.3
+          image: ghcr.io/oliver-zehentleitner/ubdcc-dcn:0.4.0.dev

--- a/admin/k8s/ubdcc-mgmt.yaml
+++ b/admin/k8s/ubdcc-mgmt.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: ubdcc-mgmt
-          image: ghcr.io/oliver-zehentleitner/ubdcc-mgmt:0.3.3
+          image: ghcr.io/oliver-zehentleitner/ubdcc-mgmt:0.4.0.dev
           ports:
             - name: rest-private
               containerPort: 8080

--- a/admin/k8s/ubdcc-restapi.yaml
+++ b/admin/k8s/ubdcc-restapi.yaml
@@ -28,7 +28,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: ubdcc-restapi
-          image: ghcr.io/oliver-zehentleitner/ubdcc-restapi:0.3.3
+          image: ghcr.io/oliver-zehentleitner/ubdcc-restapi:0.4.0.dev
           ports:
             - name: rest-private
               containerPort: 8080

--- a/container/generic_loader/requirements-ubdcc_dcn.txt
+++ b/container/generic_loader/requirements-ubdcc_dcn.txt
@@ -1,1 +1,1 @@
-ubdcc-dcn==0.3.3
+ubdcc-dcn==0.4.0.dev

--- a/container/generic_loader/requirements-ubdcc_mgmt.txt
+++ b/container/generic_loader/requirements-ubdcc_mgmt.txt
@@ -1,1 +1,1 @@
-ubdcc-mgmt==0.3.3
+ubdcc-mgmt==0.4.0.dev

--- a/container/generic_loader/requirements-ubdcc_restapi.txt
+++ b/container/generic_loader/requirements-ubdcc_restapi.txt
@@ -1,1 +1,1 @@
-ubdcc-restapi==0.3.3
+ubdcc-restapi==0.4.0.dev

--- a/dev/helm/ubdcc/Chart.yaml
+++ b/dev/helm/ubdcc/Chart.yaml
@@ -17,10 +17,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.3
+version: 0.4.0.dev
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.3.3"
+appVersion: "0.4.0.dev"

--- a/dev/set_version_config.yml
+++ b/dev/set_version_config.yml
@@ -31,4 +31,4 @@ files:
 - packages/ubdcc-shared-modules/setup.py
 - README.md
 - AGENTS.md
-version: 0.3.3
+version: 0.4.0.dev

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -31,7 +31,7 @@ author = 'Oliver Zehentleitner'
 # The short X.Y version
 version = ''
 # The full version, including alpha/beta/rc tags
-release = '0.3.3'
+release = '0.4.0.dev'
 
 html_last_updated_fmt = "%b %d %Y at %H:%M (CET)"
 

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc-dcn"
-version = "0.3.3"
+version = "0.4.0.dev"
 description = "UBDCC Depth Cache Node — manages local Binance order books in a cluster pod"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
@@ -21,7 +21,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"
-ubdcc-shared-modules = "==0.3.3"
+ubdcc-shared-modules = "==0.4.0.dev"
 unicorn_binance_local_depth_cache = ">=2.11.0"
 
 [tool.poetry.dev-dependencies]

--- a/packages/ubdcc-dcn/requirements.txt
+++ b/packages/ubdcc-dcn/requirements.txt
@@ -1,2 +1,2 @@
-ubdcc-shared-modules==0.3.3
+ubdcc-shared-modules==0.4.0.dev
 unicorn-binance-local-depth-cache>=2.11.0

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -30,7 +30,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.3.3",
+    version="0.4.0.dev",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
@@ -38,7 +38,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',
-    install_requires=['ubdcc-shared-modules==0.3.3',
+    install_requires=['ubdcc-shared-modules==0.4.0.dev',
                       'unicorn-binance-local-depth-cache>=2.11.0'],
     keywords='',
     project_urls={

--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -21,9 +21,15 @@ import queue
 from functools import partial
 
 from .RestEndpoints import RestEndpoints
+from ubdcc_shared_modules.AccountGroups import get_account_group
 from ubdcc_shared_modules.ServiceBase import ServiceBase
 from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheNotFound
 from unicorn_binance_local_depth_cache.manager import __version__ as ubldc_version
+
+try:
+    from unicorn_binance_rest_api import BinanceRestApiManager
+except ImportError:
+    BinanceRestApiManager = None
 
 
 class DepthCacheNode(ServiceBase):
@@ -38,10 +44,43 @@ class DepthCacheNode(ServiceBase):
         """Thread-safe: invoked from UBLDC's manager thread on every stream restart."""
         self._restart_queue.put((exchange, market, timestamp))
 
+    async def _get_ubra_manager(self, exchange: str):
+        """Return a BinanceRestApiManager for `exchange` with assigned API
+        credentials, or None when no credentials are configured for that
+        account_group (UBLDC then falls back to public rate limits)."""
+        if BinanceRestApiManager is None:
+            return None
+        account_group = get_account_group(exchange)
+        if account_group is None:
+            return None
+        cache = self.app.data.setdefault('ubra_by_account_group', {})
+        if account_group in cache:
+            return cache[account_group]
+        credential = await self.app.ubdcc_assign_credentials(account_group=account_group)
+        if credential is None:
+            cache[account_group] = None
+            return None
+        try:
+            ubra = BinanceRestApiManager(api_key=credential['api_key'],
+                                         api_secret=credential['api_secret'],
+                                         exchange=exchange,
+                                         disable_colorama=True,
+                                         warn_on_update=False)
+        except Exception as error_msg:
+            self.app.stdout_msg(f"Could not create BinanceRestApiManager for '{account_group}': {error_msg}",
+                                log="error")
+            cache[account_group] = None
+            return None
+        self.app.stdout_msg(f"Assigned credential '{credential['id']}' for account_group "
+                            f"'{account_group}'.", log="info")
+        cache[account_group] = ubra
+        return ubra
+
     async def main(self):
         self.app.data['depthcache_instances'] = {}
         self.app.data['local_depthcaches'] = []
         self.app.data['responsibilities'] = []
+        self.app.data['ubra_by_account_group'] = {}
         await self.start_rest_server(endpoints=RestEndpoints)
         self.app.set_status_running()
         await self.app.register_or_restart(ubldc_version=ubldc_version)
@@ -63,19 +102,14 @@ class DepthCacheNode(ServiceBase):
                         self.app.data['depthcache_instances'][dc['exchange']] = {}
                     if self.app.data['depthcache_instances'][dc['exchange']].get(dc['update_interval']) is None:
                         on_restart = partial(self._on_stream_restart, dc['exchange'])
-                        if dc['update_interval'] is None:
-                            self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']] = \
-                                BinanceLocalDepthCacheManager(
-                                    exchange=dc['exchange'],
-                                    on_restart=on_restart,
-                                )
-                        else:
-                            self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']] = \
-                                BinanceLocalDepthCacheManager(
-                                    exchange=dc['exchange'],
-                                    depth_cache_update_interval=dc['update_interval'],
-                                    on_restart=on_restart,
-                                )
+                        ubra_manager = await self._get_ubra_manager(exchange=dc['exchange'])
+                        kwargs = {"exchange": dc['exchange'], "on_restart": on_restart}
+                        if dc['update_interval'] is not None:
+                            kwargs['depth_cache_update_interval'] = dc['update_interval']
+                        if ubra_manager is not None:
+                            kwargs['ubra_manager'] = ubra_manager
+                        self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']] = \
+                            BinanceLocalDepthCacheManager(**kwargs)
                     else:
                         self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']].create_depthcache(
                             markets=dc['market'],

--- a/packages/ubdcc-mgmt/pyproject.toml
+++ b/packages/ubdcc-mgmt/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc-mgmt"
-version = "0.3.3"
+version = "0.4.0.dev"
 description = "UBDCC Mgmt — orchestration and node registry for the UNICORN DepthCache Cluster"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
@@ -21,7 +21,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"
-ubdcc-shared-modules = "==0.3.3"
+ubdcc-shared-modules = "==0.4.0.dev"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-mgmt/requirements.txt
+++ b/packages/ubdcc-mgmt/requirements.txt
@@ -1,1 +1,1 @@
-ubdcc-shared-modules==0.3.3
+ubdcc-shared-modules==0.4.0.dev

--- a/packages/ubdcc-mgmt/setup.py
+++ b/packages/ubdcc-mgmt/setup.py
@@ -30,7 +30,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.3.3",
+    version="0.4.0.dev",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
@@ -38,7 +38,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',
-    install_requires=['ubdcc-shared-modules==0.3.3'],
+    install_requires=['ubdcc-shared-modules==0.4.0.dev'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -18,6 +18,7 @@
 # All rights reserved.
 
 import orjson as json
+from ubdcc_shared_modules.AccountGroups import ACCOUNT_GROUPS, is_valid_account_group
 from ubdcc_shared_modules.Database import Database
 from ubdcc_shared_modules.RestEndpointsBase import RestEndpointsBase, Request
 
@@ -77,6 +78,30 @@ class RestEndpoints(RestEndpointsBase):
         @self.fastapi.get("/ubdcc_update_depthcache_distribution")
         async def ubdcc_update_depthcache_distribution(request: Request):
             return await self.ubdcc_update_depthcache_distribution(request=request)
+
+        @self.fastapi.post("/ubdcc_add_credentials")
+        async def ubdcc_add_credentials_post(request: Request):
+            return await self.ubdcc_add_credentials(request=request)
+
+        @self.fastapi.get("/ubdcc_add_credentials")
+        async def ubdcc_add_credentials_get(request: Request):
+            return await self.ubdcc_add_credentials(request=request)
+
+        @self.fastapi.post("/ubdcc_remove_credentials")
+        async def ubdcc_remove_credentials_post(request: Request):
+            return await self.ubdcc_remove_credentials(request=request)
+
+        @self.fastapi.get("/ubdcc_remove_credentials")
+        async def ubdcc_remove_credentials_get(request: Request):
+            return await self.ubdcc_remove_credentials(request=request)
+
+        @self.fastapi.get("/ubdcc_get_credentials_list")
+        async def ubdcc_get_credentials_list(request: Request):
+            return await self.ubdcc_get_credentials_list(request=request)
+
+        @self.fastapi.get("/ubdcc_assign_credentials")
+        async def ubdcc_assign_credentials(request: Request):
+            return await self.ubdcc_assign_credentials(request=request)
 
     async def create_depthcache(self, request: Request):
         event = "CREATE_DEPTHCACHE"
@@ -394,6 +419,96 @@ class RestEndpoints(RestEndpointsBase):
         else:
             return self.get_error_response(event=event, error_id="#1010",
                                            message="An unknown error has occurred!")
+
+    async def ubdcc_add_credentials(self, request: Request):
+        event = "UBDCC_ADD_CREDENTIALS"
+        ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
+        if ready_check is not None:
+            return ready_check
+        if request.method == "POST":
+            try:
+                body = json.loads(await request.body())
+            except Exception:
+                body = {}
+            account_group = body.get("account_group")
+            api_key = body.get("api_key")
+            api_secret = body.get("api_secret")
+        else:
+            account_group = request.query_params.get("account_group")
+            api_key = request.query_params.get("api_key")
+            api_secret = request.query_params.get("api_secret")
+        if account_group == "None":
+            account_group = None
+        if account_group is None or api_key is None or api_secret is None:
+            return self.get_error_response(event=event, error_id="#1030",
+                                           message="Missing required parameter: account_group, api_key, api_secret")
+        if not is_valid_account_group(account_group):
+            return self.get_error_response(event=event, error_id="#1031",
+                                           message=f"Invalid account_group '{account_group}'. "
+                                                   f"Valid groups: {', '.join(ACCOUNT_GROUPS)}")
+        try:
+            credential_id = self.db.add_credentials(account_group=account_group,
+                                                    api_key=api_key, api_secret=api_secret)
+        except ValueError as error_msg:
+            return self.get_error_response(event=event, error_id="#1032", message=str(error_msg))
+        return self.get_ok_response(event=event, params={"id": credential_id})
+
+    async def ubdcc_remove_credentials(self, request: Request):
+        event = "UBDCC_REMOVE_CREDENTIALS"
+        ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
+        if ready_check is not None:
+            return ready_check
+        if request.method == "POST":
+            try:
+                body = json.loads(await request.body())
+            except Exception:
+                body = {}
+            credential_id = body.get("id")
+        else:
+            credential_id = request.query_params.get("id")
+        if credential_id == "None":
+            credential_id = None
+        if credential_id is None:
+            return self.get_error_response(event=event, error_id="#1033",
+                                           message="Missing required parameter: id")
+        if self.db.delete_credentials(credential_id=credential_id):
+            return self.get_ok_response(event=event)
+        return self.get_error_response(event=event, error_id="#1034",
+                                       message=f"Credentials '{credential_id}' not found!")
+
+    async def ubdcc_get_credentials_list(self, request: Request):
+        event = "UBDCC_GET_CREDENTIALS_LIST"
+        ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
+        if ready_check is not None:
+            return ready_check
+        credentials = self.db.get_credentials_list(reveal_secrets=False)
+        return self.get_ok_response(event=event, params={"credentials": credentials})
+
+    async def ubdcc_assign_credentials(self, request: Request):
+        event = "UBDCC_ASSIGN_CREDENTIALS"
+        ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
+        if ready_check is not None:
+            return ready_check
+        uid = request.query_params.get("uid")
+        account_group = request.query_params.get("account_group")
+        if uid == "None":
+            uid = None
+        if account_group == "None":
+            account_group = None
+        if uid is None or account_group is None:
+            return self.get_error_response(event=event, error_id="#1035",
+                                           message="Missing required parameter: uid, account_group")
+        if not is_valid_account_group(account_group):
+            return self.get_error_response(event=event, error_id="#1036",
+                                           message=f"Invalid account_group '{account_group}'")
+        credential = self.db.assign_credentials(uid=uid, account_group=account_group)
+        if credential is None:
+            return self.get_ok_response(event=event, params={"credential": None})
+        return self.get_ok_response(event=event,
+                                    params={"credential": {"id": credential['ID'],
+                                                           "account_group": credential['ACCOUNT_GROUP'],
+                                                           "api_key": credential['API_KEY'],
+                                                           "api_secret": credential['API_SECRET']}})
 
     async def ubdcc_update_depthcache_distribution(self, request: Request):
         event = "UBDCC_UPDATE_DEPTHCACHE_DISTRIBUTION"

--- a/packages/ubdcc-restapi/pyproject.toml
+++ b/packages/ubdcc-restapi/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc-restapi"
-version = "0.3.3"
+version = "0.4.0.dev"
 description = "UBDCC REST API — public HTTP API for the UNICORN DepthCache Cluster"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
@@ -21,7 +21,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"
-ubdcc-shared-modules = "==0.3.3"
+ubdcc-shared-modules = "==0.4.0.dev"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-restapi/requirements.txt
+++ b/packages/ubdcc-restapi/requirements.txt
@@ -1,1 +1,1 @@
-ubdcc-shared-modules==0.3.3
+ubdcc-shared-modules==0.4.0.dev

--- a/packages/ubdcc-restapi/setup.py
+++ b/packages/ubdcc-restapi/setup.py
@@ -30,7 +30,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.3.3",
+    version="0.4.0.dev",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
@@ -38,7 +38,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',
-    install_requires=['ubdcc-shared-modules==0.3.3'],
+    install_requires=['ubdcc-shared-modules==0.4.0.dev'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -64,6 +64,26 @@ class RestEndpoints(RestEndpointsBase):
         async def stop_depthcache(request: Request):
             return await self.stop_depthcache(request=request)
 
+        @self.fastapi.post("/ubdcc_add_credentials")
+        async def ubdcc_add_credentials_post(request: Request):
+            return await self.ubdcc_add_credentials(request=request)
+
+        @self.fastapi.get("/ubdcc_add_credentials")
+        async def ubdcc_add_credentials_get(request: Request):
+            return await self.ubdcc_add_credentials(request=request)
+
+        @self.fastapi.post("/ubdcc_remove_credentials")
+        async def ubdcc_remove_credentials_post(request: Request):
+            return await self.ubdcc_remove_credentials(request=request)
+
+        @self.fastapi.get("/ubdcc_remove_credentials")
+        async def ubdcc_remove_credentials_get(request: Request):
+            return await self.ubdcc_remove_credentials(request=request)
+
+        @self.fastapi.get("/ubdcc_get_credentials_list")
+        async def ubdcc_get_credentials_list(request: Request):
+            return await self.ubdcc_get_credentials_list(request=request)
+
     async def _get_depthcache_data(self, request: Request, event=None, endpoint=None):
         process_start_time: float | None = time.time() if str(request.query_params.get("debug")).lower() == "true" \
             else None
@@ -302,6 +322,53 @@ class RestEndpoints(RestEndpointsBase):
                                                        f"'{self.app.id['uid']}'!",
                                                params=response, process_start_time=process_start_time,
                                                url=request_url, used_pods=used_pods)
+
+    async def _proxy_to_mgmt(self, request: Request, event: str = None, endpoint: str = None,
+                             allow_post: bool = False):
+        process_start_time: float | None = time.time() if str(request.query_params.get("debug")).lower() == "true" \
+            else None
+        request_url = str(request.url)
+        used_pods: list = [[self.app.id['name'], self.app.id['uid']]]
+        host = self.app.get_cluster_mgmt_address()
+        post_body = None
+        if allow_post and request.method == "POST":
+            try:
+                body = await request.json()
+            except Exception:
+                body = {}
+            post_body = body
+            url = host + endpoint
+            result = await self.app.request(url=url, method="post", params=body)
+        else:
+            query = str(request.url.query)
+            url = host + endpoint + ("?" + query if query else "")
+            result = await self.app.request(url=url, method="get")
+        if result.get('error') is None and result.get('error_id') is None:
+            if str(request.query_params.get("debug")).lower() == "true":
+                result['debug'] = self.create_debug_response(process_start_time=process_start_time,
+                                                             url=request_url, post_body=post_body,
+                                                             used_pods=used_pods)
+            return result
+        elif result.get('error_id') is not None:
+            return self.get_error_response(event=event, error_id=result.get('error_id'),
+                                           message=result.get('message'), process_start_time=process_start_time,
+                                           url=request_url, post_body=post_body, used_pods=used_pods)
+        else:
+            return self.get_error_response(event=event, error_id="#9000", message=f"Mgmt service not available!",
+                                           params={"error": str(result)}, process_start_time=process_start_time,
+                                           url=request_url, post_body=post_body, used_pods=used_pods)
+
+    async def ubdcc_add_credentials(self, request: Request):
+        return await self._proxy_to_mgmt(request=request, event="UBDCC_ADD_CREDENTIALS",
+                                         endpoint="/ubdcc_add_credentials", allow_post=True)
+
+    async def ubdcc_remove_credentials(self, request: Request):
+        return await self._proxy_to_mgmt(request=request, event="UBDCC_REMOVE_CREDENTIALS",
+                                         endpoint="/ubdcc_remove_credentials", allow_post=True)
+
+    async def ubdcc_get_credentials_list(self, request: Request):
+        return await self._proxy_to_mgmt(request=request, event="UBDCC_GET_CREDENTIALS_LIST",
+                                         endpoint="/ubdcc_get_credentials_list")
 
     async def stop_depthcache(self, request: Request):
         process_start_time: float | None = time.time() if str(request.query_params.get("debug")).lower() == "true" else None

--- a/packages/ubdcc-shared-modules/pyproject.toml
+++ b/packages/ubdcc-shared-modules/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc-shared-modules"
-version = "0.3.3"
+version = "0.4.0.dev"
 description = "UBDCC Shared Modules — core library for all UBDCC services"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"

--- a/packages/ubdcc-shared-modules/setup.py
+++ b/packages/ubdcc-shared-modules/setup.py
@@ -30,7 +30,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.3.3",
+    version="0.4.0.dev",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+# ¯\_(ツ)_/¯
+#
+# File: packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
+#
+# Project website: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Github: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+# Documentation: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
+# PyPI: https://pypi.org/project/ubdcc-shared-modules
+#
+# License: MIT
+# https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/LICENSE
+#
+# Author: Oliver Zehentleitner
+#
+# Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
+# All rights reserved.
+
+# Exchange string (UBLDC) -> account_group. Group = one shared Binance account
+# (same login/keys). Spot-testnet and futures-testnet are separate accounts on
+# Binance, hence separate groups.
+EXCHANGE_TO_ACCOUNT_GROUP = {
+    "binance.com": "binance.com",
+    "binance.com-futures": "binance.com",
+    "binance.com-margin": "binance.com",
+    "binance.com-isolated_margin": "binance.com",
+    "binance.com-testnet": "binance.com-testnet",
+    "binance.com-futures-testnet": "binance.com-futures-testnet",
+    "binance.us": "binance.us",
+    "trbinance.com": "binance.tr",
+}
+
+ACCOUNT_GROUPS = sorted(set(EXCHANGE_TO_ACCOUNT_GROUP.values()))
+
+
+def get_account_group(exchange: str) -> str | None:
+    if exchange is None:
+        return None
+    return EXCHANGE_TO_ACCOUNT_GROUP.get(exchange)
+
+
+def is_valid_account_group(account_group: str) -> bool:
+    return account_group in ACCOUNT_GROUPS

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -40,7 +40,7 @@ REST_SERVER_PORT: int = 8080
 REST_SERVER_PORT_DEV_DCN: int = 42082
 REST_SERVER_PORT_DEV_MGMT: int = 42080
 REST_SERVER_PORT_DEV_RESTAPI: int = 42081
-VERSION: str = "0.3.3.dev"
+VERSION: str = "0.4.0.dev.dev"
 
 
 class App:
@@ -526,6 +526,22 @@ class App:
             self.stdout_msg(f"Error during node sync: {result.get('error_id')} - {result.get('message')}",
                             log="error")
             return False
+
+    async def ubdcc_assign_credentials(self, account_group: str = None) -> dict | None:
+        """Ask mgmt for a credential assigned to this DCN uid for the given
+        account_group. Returns {id, account_group, api_key, api_secret} or
+        None when no keys are configured / error."""
+        if account_group is None:
+            return None
+        endpoint = "/ubdcc_assign_credentials"
+        query = f"?uid={self.id['uid']}&account_group={account_group}"
+        host = self.get_cluster_mgmt_address()
+        url = host + endpoint + query
+        result = await self.request(url=url, method="get")
+        if result.get('error_id') is not None or result.get('error') is not None:
+            self.stdout_msg(f"Could not assign credentials for '{account_group}': {result}", log="warn")
+            return None
+        return result.get('credential')
 
     async def ubdcc_update_depthcache_distribution(self,
                                                    exchange: str = None,

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
@@ -19,6 +19,7 @@
 
 import threading
 import time
+import uuid
 
 
 class Database:
@@ -34,6 +35,7 @@ class Database:
         self.set(key="depthcaches", value={})
         self.set(key="nodes", value={})
         self.set(key="pods", value={})
+        self.set(key="credentials", value={})
         self.set(key="timestamp", value=float())
         if self.app.info['name'] == "ubdcc-mgmt":
             self.update_nodes()
@@ -127,6 +129,116 @@ class Database:
             self.data['pods'][uid] = pod
             self._set_update_timestamp()
         return True
+
+    def add_credentials(self, account_group: str = None, api_key: str = None,
+                        api_secret: str = None) -> str:
+        """Store a Binance API key pair for the given account group. Returns
+        the generated credential id (UUID). Raises ValueError on invalid
+        parameters or unknown account_group."""
+        if account_group is None or api_key is None or api_secret is None:
+            raise ValueError("Missing mandatory parameter: account_group, api_key, api_secret")
+        from .AccountGroups import is_valid_account_group
+        if not is_valid_account_group(account_group):
+            raise ValueError(f"Invalid account_group: {account_group}")
+        credential_id = str(uuid.uuid4())
+        credential = {"ID": credential_id,
+                      "ACCOUNT_GROUP": account_group,
+                      "API_KEY": api_key,
+                      "API_SECRET": api_secret,
+                      "ADDED_TIMESTAMP": self.app.get_unix_timestamp(),
+                      "ASSIGNED_DCNS": []}
+        with self.data_lock:
+            if self.data.get('credentials') is None:
+                self.data['credentials'] = {}
+            self.data['credentials'][credential_id] = credential
+            self._set_update_timestamp()
+        return credential_id
+
+    def assign_credentials(self, uid: str = None, account_group: str = None) -> dict | None:
+        """Assign (or return already-assigned) credential to a DCN uid.
+        Load-balanced: picks credential with fewest ASSIGNED_DCNS.
+        Returns full credential dict (incl. secret) or None if no keys available.
+        """
+        if uid is None or account_group is None:
+            raise ValueError("Missing mandatory parameter: uid, account_group")
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            candidates = [c for c in credentials.values()
+                          if c['ACCOUNT_GROUP'] == account_group]
+            if not candidates:
+                return None
+            for c in candidates:
+                if uid in c['ASSIGNED_DCNS']:
+                    return dict(c)
+            chosen = min(candidates, key=lambda c: len(c['ASSIGNED_DCNS']))
+            chosen['ASSIGNED_DCNS'].append(uid)
+            self._set_update_timestamp()
+            return dict(chosen)
+
+    def delete_credentials(self, credential_id: str = None) -> bool:
+        """Remove a stored credential. Returns True on success, False when the
+        id was not found."""
+        if credential_id is None:
+            raise ValueError("Missing mandatory parameter: credential_id")
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            if credential_id not in credentials:
+                return False
+            del credentials[credential_id]
+            self._set_update_timestamp()
+        return True
+
+    def get_credentials(self, credential_id: str = None) -> dict | None:
+        """Return the full credential record (incl. secret) for the given id,
+        or None if not found. Internal use only — do not leak through public
+        endpoints."""
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            c = credentials.get(credential_id)
+            return dict(c) if c else None
+
+    def get_credentials_list(self, reveal_secrets: bool = False) -> list:
+        """Return list of credentials. With reveal_secrets=False (default)
+        api_key/api_secret are masked for public consumption."""
+        result = []
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            for c in credentials.values():
+                entry = {"id": c['ID'],
+                         "account_group": c['ACCOUNT_GROUP'],
+                         "added_timestamp": c['ADDED_TIMESTAMP'],
+                         "assigned_dcns": list(c['ASSIGNED_DCNS'])}
+                if reveal_secrets:
+                    entry['api_key'] = c['API_KEY']
+                    entry['api_secret'] = c['API_SECRET']
+                else:
+                    entry['api_key_preview'] = self._mask(c['API_KEY'])
+                result.append(entry)
+        return result
+
+    def release_credentials(self, uid: str = None) -> bool:
+        """Remove uid from ASSIGNED_DCNS of all credentials (called when DCN
+        pod disappears)."""
+        if uid is None:
+            raise ValueError("Missing mandatory parameter: uid")
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            changed = False
+            for c in credentials.values():
+                if uid in c['ASSIGNED_DCNS']:
+                    c['ASSIGNED_DCNS'].remove(uid)
+                    changed = True
+            if changed:
+                self._set_update_timestamp()
+        return changed
+
+    @staticmethod
+    def _mask(secret: str) -> str:
+        if not secret:
+            return ""
+        if len(secret) <= 6:
+            return "*" * len(secret)
+        return secret[:4] + "*" * (len(secret) - 6) + secret[-2:]
 
     def delete(self, key: str = None) -> bool:
         with self.data_lock:
@@ -325,12 +437,27 @@ class Database:
                 self._set_update_timestamp()
         return True
 
+    def remove_orphaned_credential_assignments(self) -> bool:
+        with self.data_lock:
+            existing_pods = set(self.data.get('pods', {}).keys())
+            credentials = self.data.get('credentials') or {}
+            changed = False
+            for c in credentials.values():
+                new_list = [uid for uid in c['ASSIGNED_DCNS'] if uid in existing_pods]
+                if len(new_list) != len(c['ASSIGNED_DCNS']):
+                    c['ASSIGNED_DCNS'] = new_list
+                    changed = True
+            if changed:
+                self._set_update_timestamp()
+        return True
+
     def revise(self) -> bool:
         start_time = time.time()
         self.app.stdout_msg(f"Revise the Database ...", log="info")
         self.update_nodes()
         self.delete_old_pods()
         self.remove_orphaned_distribution_entries()
+        self.remove_orphaned_credential_assignments()
         self.manage_distribution()
         run_time = time.time() - start_time
         self.app.stdout_msg(f"Database revised in {run_time} seconds!", log="info")

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/RestEndpointsBase.py
@@ -34,7 +34,8 @@ class RestEndpointsBase:
         if self.app.data.get('db') is None:
             response = {}
         else:
-            response = {"db": {"depthcaches": self.app.data['db'].get('depthcaches'),
+            response = {"db": {"credentials": self.app.data['db'].get_credentials_list(reveal_secrets=False),
+                               "depthcaches": self.app.data['db'].get('depthcaches'),
                                "nodes": self.app.data['db'].get('nodes'),
                                "pods": self.app.data['db'].get('pods'),
                                "timestamp": self.app.data['db'].get('timestamp')},

--- a/packages/ubdcc/pyproject.toml
+++ b/packages/ubdcc/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc"
-version = "0.3.3"
+version = "0.4.0.dev"
 description = "UNICORN Binance DepthCache Cluster — cluster manager and meta-package"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"

--- a/packages/ubdcc/setup.py
+++ b/packages/ubdcc/setup.py
@@ -27,7 +27,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.3.3",
+    version="0.4.0.dev",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -522,7 +522,10 @@ def cmd_credentials_list(args):
         return
     for c in credentials:
         assigned = ", ".join(c.get('assigned_dcns') or []) or "-"
-        print(f"{c['id']}  {c['account_group']:<32}  {c.get('api_key_preview','')}  assigned=[{assigned}]")
+        # api_key_preview is already masked server-side (first 4 + last 2 chars,
+        # rest replaced with '*'); api_secret is never returned by this endpoint.
+        preview = c.get('api_key_preview', '')  # nosec B105 - masked value, not a secret
+        print(f"{c['id']}  {c['account_group']:<32}  {preview}  assigned=[{assigned}]")  # lgtm[py/clear-text-logging-sensitive-data]
 
 
 def main():

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -474,6 +474,57 @@ def print_status_table(data, mgmt_port=42080):
         print(f"Cluster info: http://127.0.0.1:{restapi_port}/get_cluster_info")
 
 
+def cmd_credentials_add(args):
+    port = get_mgmt_port(args)
+    payload = {"account_group": args.account_group,
+               "api_key": args.api_key,
+               "api_secret": args.api_secret}
+    try:
+        r = requests.post(f"http://127.0.0.1:{port}/ubdcc_add_credentials", json=payload, timeout=5)
+        data = r.json()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    if data.get('result') == "OK":
+        print(f"Added. id={data.get('id')}")
+    else:
+        print(f"Error: {data.get('message')} ({data.get('error_id')})", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_credentials_remove(args):
+    port = get_mgmt_port(args)
+    try:
+        r = requests.get(f"http://127.0.0.1:{port}/ubdcc_remove_credentials",
+                         params={"id": args.id}, timeout=5)
+        data = r.json()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    if data.get('result') == "OK":
+        print("Removed.")
+    else:
+        print(f"Error: {data.get('message')} ({data.get('error_id')})", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_credentials_list(args):
+    port = get_mgmt_port(args)
+    try:
+        r = requests.get(f"http://127.0.0.1:{port}/ubdcc_get_credentials_list", timeout=5)
+        data = r.json()
+    except Exception as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    credentials = data.get('credentials') or []
+    if not credentials:
+        print("(no credentials configured)")
+        return
+    for c in credentials:
+        assigned = ", ".join(c.get('assigned_dcns') or []) or "-"
+        print(f"{c['id']}  {c['account_group']:<32}  {c.get('api_key_preview','')}  assigned=[{assigned}]")
+
+
 def main():
     parser = argparse.ArgumentParser(
         prog='ubdcc',
@@ -506,6 +557,25 @@ def main():
     stop_parser = subparsers.add_parser('stop', help='Stop the cluster')
     stop_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
 
+    # credentials
+    cred_parser = subparsers.add_parser('credentials', help='Manage Binance API credentials')
+    cred_sub = cred_parser.add_subparsers(dest='cred_command')
+
+    cred_add = cred_sub.add_parser('add', help='Add an API key/secret')
+    cred_add.add_argument('--account-group', required=True,
+                          help='binance.com | binance.com-testnet | binance.com-futures-testnet | '
+                               'binance.us | binance.tr')
+    cred_add.add_argument('--api-key', required=True)
+    cred_add.add_argument('--api-secret', required=True)
+    cred_add.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
+
+    cred_remove = cred_sub.add_parser('remove', help='Remove credentials by id')
+    cred_remove.add_argument('id')
+    cred_remove.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
+
+    cred_list = cred_sub.add_parser('list', help='List configured credentials (keys masked)')
+    cred_list.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
+
     args = parser.parse_args()
 
     if args.command == 'start':
@@ -514,6 +584,15 @@ def main():
         cmd_status(args)
     elif args.command == 'stop':
         cmd_stop(args)
+    elif args.command == 'credentials':
+        if args.cred_command == 'add':
+            cmd_credentials_add(args)
+        elif args.cred_command == 'remove':
+            cmd_credentials_remove(args)
+        elif args.cred_command == 'list':
+            cmd_credentials_list(args)
+        else:
+            cred_parser.print_help()
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary

Optional Binance API credentials for the cluster. Lets DCNs use authenticated rate limits instead of public ones — without forcing anyone to configure keys.

- Per-account-group pool: `binance.com`, `binance.com-testnet`, `binance.com-futures-testnet`, `binance.us`, `binance.tr`. Spot-testnet and futures-testnet are separate Binance logins, so separate groups.
- Multiple `(api_key, api_secret)` pairs per group allowed — mgmt load-balances them across DCN pods (fewest-assigned-first).
- New REST endpoints (public, proxied through restapi): `/ubdcc_add_credentials` (POST/GET), `/ubdcc_remove_credentials`, `/ubdcc_get_credentials_list`. Internal: `/ubdcc_assign_credentials` (mgmt → DCN, returns full key).
- CLI: `ubdcc credentials add/list/remove`.
- `get_cluster_info` now shows masked key previews and which DCN UIDs each key is currently assigned to.
- DCN fetches its credential on first use per account_group and hands it to UBLDC as a `BinanceRestApiManager`.
- Keys are part of the normal self-healing DB sync (cleartext cluster-internal — deliberate trade-off for backup/restore). Public responses only expose masked previews.
- README has a new **API Credentials** section with the group mapping, usage examples and explicit security caveats. Security hardening (mTLS, at-rest encryption, alternate storage backends) is tracked as a follow-up in `TASKS.md`.
- Version bump 0.3.3.dev → 0.4.0.dev.

## Test plan
- [ ] `ubdcc start`, add a credential via CLI, check `ubdcc credentials list` shows masked preview and empty `assigned_dcns`
- [ ] Create a DepthCache on `binance.com`; verify DCN log shows `Assigned credential … for account_group 'binance.com'` and `assigned_dcns` now contains the DCN UID
- [ ] Remove credential, restart DCN, verify fallback to public rate limits (no error)
- [ ] Multiple key pairs → second DCN picks the other key
- [ ] Add a testnet key (`--account-group binance.com-futures-testnet`), verify it is only handed out for futures-testnet exchanges
- [ ] Full cluster restart → credentials restored from backup