### PR TITLE
Fix DCN crash on startup: _restart_queue init order

### DIFF
--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -34,11 +34,14 @@ except ImportError:
 
 class DepthCacheNode(ServiceBase):
     def __init__(self, cwd=None, mgmt_port=None):
-        super().__init__(app_name="ubdcc-dcn", cwd=cwd, mgmt_port=mgmt_port)
         # Thread-safe queue: UBLDC on_restart callbacks fire from their
         # manager thread; the async main loop drains the queue and forwards
-        # to mgmt. (exchange, market, timestamp) tuples.
+        # to mgmt. Must be initialized BEFORE super().__init__() because
+        # ServiceBase.__init__() calls self.app.start() which blocks and
+        # synchronously runs main() → _drain_restart_queue(). Any attribute
+        # set after super().__init__() is never assigned.
         self._restart_queue: queue.Queue = queue.Queue()
+        super().__init__(app_name="ubdcc-dcn", cwd=cwd, mgmt_port=mgmt_port)
 
     def _on_stream_restart(self, exchange: str, market: str, timestamp: float) -> None:
         """Thread-safe: invoked from UBLDC's manager thread on every stream restart."""


### PR DESCRIPTION
## Summary
DCNs crashed seconds after successful registration with:
\`\`\`
File \"ubdcc_dcn/DepthCacheNode.py\", line 158, in _drain_restart_queue
AttributeError: 'DepthCacheNode' object has no attribute '_restart_queue'
\`\`\`

Root cause: \`ServiceBase.__init__()\` calls \`self.app.start()\` which **blocks** and synchronously runs \`main()\` (the \`# Never gets executed ;)\` comment on the line right after \`self.app.start()\` in ServiceBase.__init__ flags this). So in \`DepthCacheNode.__init__\`, any line *after* \`super().__init__()\` is never reached — including \`self._restart_queue = queue.Queue()\`. First call to \`_drain_restart_queue\` then blows up.

Fix: one-line reorder — initialize \`_restart_queue\` **before** \`super().__init__()\`.

## Reproduction (without the fix)
\`\`\`
ubdcc start --dcn=3
# wait ~15s, then:
curl -s http://127.0.0.1:42081/get_cluster_info | jq .db.pods
# → only restapi remains (plus any zombie from a previous backup)
tail /tmp/ubdcc-test/ubdcc-dcn-*.log
# → AttributeError '_restart_queue'
\`\`\`

## Test plan
- [x] Reproduced the crash locally with \`ubdcc start --dcn=3\`
- [x] Applied fix, rebuilt Cython \`.so\`, restarted — all 3 DCNs stay registered, node_sync loop clean
- [ ] Review whether a guard against \`super().__init__()\` side-effects would be appropriate long-term (the current \`ServiceBase.__init__\` design is footgun-prone; out of scope for this fix)

## Follow-up (not in this PR)
Stale DCN entries survive across restarts via the mgmt backup DB and show up in \`get_cluster_info\` with outdated ports — tracked separately.