### PR TITLE
Fix missing AccountGroups module in shared-modules package

### DIFF
--- a/packages/ubdcc-shared-modules/setup.py
+++ b/packages/ubdcc-shared-modules/setup.py
@@ -51,6 +51,7 @@ setup(
         'Telegram': 'https://t.me/unicorndevs',
     },
     ext_modules=cythonize(['ubdcc_shared_modules/__init__.py',
+                           'ubdcc_shared_modules/AccountGroups.py',
                            'ubdcc_shared_modules/App.py',
                            'ubdcc_shared_modules/Database.py',
                            'ubdcc_shared_modules/RestEndpointsBase.py',


### PR DESCRIPTION
## Summary
- Add `AccountGroups.py` to the `cythonize()` list in `ubdcc-shared-modules/setup.py`
- The module was added in the credentials feature (d4e7ce4) but not included in the cythonize list
- Since `exclude_package_data` drops all `*.py` files, AccountGroups was completely absent from the built package → `ModuleNotFoundError` at DCN startup

## Test plan
- [ ] Rebuild shared-modules package
- [ ] `ubdcc start` — verify DCN starts without `ModuleNotFoundError: No module named 'ubdcc_shared_modules.AccountGroups'`