### PR TITLE
Pin internal UBDCC dependencies to ==0.4.0

### DIFF
--- a/packages/ubdcc-shared-modules/setup.py
+++ b/packages/ubdcc-shared-modules/setup.py
@@ -51,6 +51,7 @@ setup(
         'Telegram': 'https://t.me/unicorndevs',
     },
     ext_modules=cythonize(['ubdcc_shared_modules/__init__.py',
+                           'ubdcc_shared_modules/AccountGroups.py',
                            'ubdcc_shared_modules/App.py',
                            'ubdcc_shared_modules/Database.py',
                            'ubdcc_shared_modules/RestEndpointsBase.py',

--- a/packages/ubdcc/pyproject.toml
+++ b/packages/ubdcc/pyproject.toml
@@ -21,9 +21,9 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 
 [tool.poetry.dependencies]
 python = ">=3.9.0"
-ubdcc-mgmt = "*"
-ubdcc-restapi = "*"
-ubdcc-dcn = "*"
+ubdcc-mgmt = "==0.4.0"
+ubdcc-restapi = "==0.4.0"
+ubdcc-dcn = "==0.4.0"
 
 [tool.poetry.scripts]
 ubdcc = "ubdcc.cli:main"

--- a/packages/ubdcc/requirements.txt
+++ b/packages/ubdcc/requirements.txt
@@ -1,3 +1,3 @@
-ubdcc-mgmt
-ubdcc-restapi
-ubdcc-dcn
+ubdcc-mgmt==0.4.0
+ubdcc-restapi==0.4.0
+ubdcc-dcn==0.4.0

--- a/packages/ubdcc/setup.py
+++ b/packages/ubdcc/setup.py
@@ -36,9 +36,9 @@ setup(
     long_description_content_type="text/markdown",
     license='MIT',
     packages=find_packages(),
-    install_requires=['ubdcc-mgmt',
-                      'ubdcc-restapi',
-                      'ubdcc-dcn'],
+    install_requires=['ubdcc-mgmt==0.4.0',
+                      'ubdcc-restapi==0.4.0',
+                      'ubdcc-dcn==0.4.0'],
     entry_points={
         "console_scripts": [
             "ubdcc=ubdcc.cli:main",


### PR DESCRIPTION
## Summary
- Pin `ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn` to `==0.4.0` in the `ubdcc` meta-package
- Updated in `setup.py`, `pyproject.toml`, and `requirements.txt`
- Ensures `pip install ubdcc` always pulls matching sub-package versions

## Test plan
- [ ] `pip install ubdcc` resolves all sub-packages to 0.4.0