### PR TITLE
CLI status: show UBLDC version and redundancy summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,12 +186,13 @@ ROLE             NAME                 PORT     STATUS     VERSION
 ----------------------------------------------------------------------
 ubdcc-mgmt       ubdcc-mgmt           42080    running    0.4.1
 ubdcc-restapi    TDMKiCnT6jZ39N       42081    running    0.4.1
-ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.4.1
-ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.4.1
-ubdcc-dcn        tDuu9mOXrt445XU      42084    running    0.4.1
-ubdcc-dcn        xg6RZRf1APErfh1      42085    running    0.4.1
+ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.4.1 (ubldc 2.8.1)
+ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.4.1 (ubldc 2.8.1)
+ubdcc-dcn        tDuu9mOXrt445XU      42084    running    0.4.1 (ubldc 2.8.1)
+ubdcc-dcn        xg6RZRf1APErfh1      42085    running    0.4.1 (ubldc 2.8.1)
 
-DepthCaches: 0
+DepthCaches: 0 (0 replicas: 0 running, 0 starting)
+Redundancy: 0 fully redundant, 0 degraded, 0 no redundancy
 Version: 0.4.1
 
 REST API: http://127.0.0.1:42081/

--- a/README.md
+++ b/README.md
@@ -186,10 +186,10 @@ ROLE             NAME                 PORT     STATUS     VERSION
 ----------------------------------------------------------------------
 ubdcc-mgmt       ubdcc-mgmt           42080    running    0.4.1
 ubdcc-restapi    TDMKiCnT6jZ39N       42081    running    0.4.1
-ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.4.1 (ubldc 2.8.1)
-ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.4.1 (ubldc 2.8.1)
-ubdcc-dcn        tDuu9mOXrt445XU      42084    running    0.4.1 (ubldc 2.8.1)
-ubdcc-dcn        xg6RZRf1APErfh1      42085    running    0.4.1 (ubldc 2.8.1)
+ubdcc-dcn        g3HcyluSZ5qWarm      42082    running    0.4.1 (ubldc 2.11.2)
+ubdcc-dcn        gpU3hkiU9Ei          42083    running    0.4.1 (ubldc 2.11.2)
+ubdcc-dcn        tDuu9mOXrt445XU      42084    running    0.4.1 (ubldc 2.11.2)
+ubdcc-dcn        xg6RZRf1APErfh1      42085    running    0.4.1 (ubldc 2.11.2)
 
 DepthCaches: 0 (0 replicas: 0 running, 0 starting)
 Redundancy: 0 fully redundant, 0 degraded, 0 no redundancy

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -461,13 +461,40 @@ def print_status_table(data, mgmt_port=42080):
         port = pod.get('API_PORT_REST', '?')
         status = pod.get('STATUS', '?')
         version = pod.get('VERSION', '?')
+        ubldc_version = pod.get('UBLDC_VERSION')
+        if ubldc_version:
+            version = f"{version} (ubldc {ubldc_version})"
         print(f"{role:<16} {name:<20} {port:<8} {status:<10} {version}")
         if role == 'ubdcc-restapi' and restapi_port is None:
             restapi_port = port
 
     depthcaches = data.get('db', {}).get('depthcaches', {})
-    dc_count = sum(len(markets) for markets in depthcaches.values())
-    print(f"\nDepthCaches: {dc_count}")
+    dc_count = 0
+    total_replicas = 0
+    replicas_running = 0
+    replicas_starting = 0
+    fully_redundant = 0
+    degraded = 0
+    no_redundancy = 0
+    for markets in depthcaches.values():
+        for dc in markets.values():
+            dc_count += 1
+            desired = dc.get('DESIRED_QUANTITY', 1)
+            distribution = dc.get('DISTRIBUTION', {})
+            running = sum(1 for d in distribution.values() if d.get('STATUS') == 'running')
+            starting = len(distribution) - running
+            total_replicas += len(distribution)
+            replicas_running += running
+            replicas_starting += starting
+            if desired < 2:
+                no_redundancy += 1
+            elif running >= desired:
+                fully_redundant += 1
+            else:
+                degraded += 1
+
+    print(f"\nDepthCaches: {dc_count} ({total_replicas} replicas: {replicas_running} running, {replicas_starting} starting)")
+    print(f"Redundancy: {fully_redundant} fully redundant, {degraded} degraded, {no_redundancy} no redundancy")
     print(f"Version: {data.get('version', '?')}")
     if restapi_port:
         print(f"\nREST API: http://127.0.0.1:{restapi_port}/")


### PR DESCRIPTION
## Summary
- Show UBLDC version in parentheses next to each DCN's version in `ubdcc status` output, e.g. `0.4.1 (ubldc 2.11.2)`
- Add replica breakdown to DepthCaches line: total replicas, running, starting
- Add redundancy summary categorizing each DepthCache as fully redundant (desired >= 2 and all running), degraded (desired >= 2 but not all running), or no redundancy (desired < 2)
- Update README example output to reflect the new format

## Test plan
- [ ] Run `ubdcc status` on a cluster with running DepthCaches and verify UBLDC version shows on DCN rows
- [ ] Verify replica counts match actual distribution state
- [ ] Test with `desired_quantity=1` to confirm "no redundancy" category
- [ ] Test with a degraded DCN to confirm "degraded" count

🤖 Generated with [Claude Code](https://claude.com/claude-code)