### PR TITLE
CHANGELOG: CLI status UBLDC version and redundancy summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.4.1.dev (development stage/unreleased/unstable)
+### Added
+- CLI `status`: show UBLDC version in parentheses next to each DCN's version
+- CLI `status`: DepthCache redundancy summary — replica breakdown (running/starting) and redundancy categories (fully redundant, degraded, no redundancy)
 
 ## 0.4.1
 ### Fixed


### PR DESCRIPTION
## Summary
- Add CHANGELOG entries for the CLI status enhancements from #103: UBLDC version display on DCNs and DepthCache redundancy summary

## Test plan
- [ ] Verify CHANGELOG formatting matches existing entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)