### PR TITLE
Add Vanilla Options exchange strings to AccountGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Added
 - CLI `status`: show UBLDC version in parentheses next to each DCN's version
 - CLI `status`: DepthCache redundancy summary — replica breakdown (running/starting) and redundancy categories (fully redundant, degraded, no redundancy)
+- AccountGroups: `binance.com-vanilla-options` → `binance.com`, `binance.com-vanilla-options-testnet` → `binance.com-futures-testnet`
 
 ## 0.4.1
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ the internet typically ~60ms.
 | [Binance Testnet](https://testnet.binance.vision/)                 | `binance.com-testnet`         |
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
+| [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |
+| [Binance European Options Testnet](https://testnet.binancefuture.com) | `binance.com-vanilla-options-testnet` |
 | [Binance US](https://www.binance.us/)                              | `binance.us`                  |
 | [Binance TR](https://www.trbinance.com)                            | `trbinance.com`               |
 
@@ -502,9 +504,9 @@ Each Binance account has its own keys. UBDCC groups related exchanges under one 
 
 | account_group                   | Covers UBLDC exchanges                                                                                       |
 |---------------------------------|--------------------------------------------------------------------------------------------------------------|
-| `binance.com`                   | `binance.com`, `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`                    |
+| `binance.com`                   | `binance.com`, `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`, `binance.com-vanilla-options` |
 | `binance.com-testnet`           | `binance.com-testnet` (Spot testnet — separate login on testnet.binance.vision)                              |
-| `binance.com-futures-testnet`   | `binance.com-futures-testnet` (Futures testnet — separate login on testnet.binancefuture.com)                |
+| `binance.com-futures-testnet`   | `binance.com-futures-testnet`, `binance.com-vanilla-options-testnet` (shared Futures/Options testnet)        |
 | `binance.us`                    | `binance.us`                                                                                                 |
 | `binance.tr`                    | `trbinance.com`                                                                                              |
 

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 [tool.poetry.dependencies]
 python = ">=3.9.0"
 ubdcc-shared-modules = "==0.4.1"
-unicorn_binance_local_depth_cache = ">=2.11.0"
+unicorn_binance_local_depth_cache = ">=2.12.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type="text/markdown",
     license='MIT',
     install_requires=['ubdcc-shared-modules==0.4.1',
-                      'unicorn-binance-local-depth-cache>=2.11.0'],
+                      'unicorn-binance-local-depth-cache>=2.12.0'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
@@ -25,8 +25,10 @@ EXCHANGE_TO_ACCOUNT_GROUP = {
     "binance.com-futures": "binance.com",
     "binance.com-margin": "binance.com",
     "binance.com-isolated_margin": "binance.com",
+    "binance.com-vanilla-options": "binance.com",
     "binance.com-testnet": "binance.com-testnet",
     "binance.com-futures-testnet": "binance.com-futures-testnet",
+    "binance.com-vanilla-options-testnet": "binance.com-futures-testnet",
     "binance.us": "binance.us",
     "trbinance.com": "binance.tr",
 }


### PR DESCRIPTION
## Summary
- Map `binance.com-vanilla-options` → `binance.com` account group (same Binance account as Spot/Futures)
- Map `binance.com-vanilla-options-testnet` → `binance.com-futures-testnet` (shared testnet)
- Part 4/4 of Vanilla Options depth cache integration (UBRA → UBWA → UBLDC → **UBDCC**)

## Note
UBLDC dependency bump in ubdcc-dcn (setup.py/pyproject.toml) should be done once the new UBLDC version is released and the version number is known.

## Test plan
- [x] AccountGroups mapping is correct (Options shares credentials with Spot/Futures)
- [ ] End-to-end: `ubdcc start` → create Options depth cache via REST API