### PR TITLE
Remove Gitter references

### DIFF
--- a/container/generic_loader/README.md
+++ b/container/generic_loader/README.md
@@ -15,7 +15,6 @@
 [![Read the Docs](https://img.shields.io/badge/read-%20docs-yellow)](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
-[![Gitter](https://img.shields.io/badge/community-gitter-41ab8c)](https://gitter.im/unicorn-trading-suite/unicorn-binance-depth-cache-cluster?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # UNICORN Binance DepthCache Cluster - UBDCC Generic Loader (Docker Image)
 


### PR DESCRIPTION
## Summary
- Remove Gitter badge from `container/generic_loader/README.md` (Gitter service is dead)

## Test plan
- [ ] Verify the badge line is removed and README renders correctly