### PR TITLE
Update Python versions in bug report template (3.9-3.14)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -40,6 +40,9 @@ body:
         - Python3.14
         - Python3.13
         - Python3.12
+        - Python3.11
+        - Python3.10
+        - Python3.9
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
- Added Python 3.9, 3.10, and 3.11 to the bug report issue template dropdown
- The template previously only listed 3.12, 3.13, 3.14 despite the package supporting 3.9+

## Test plan
- [ ] Verify the bug report template renders correctly on GitHub with all six Python versions listed