### PR TITLE
Migrate config/log paths to ~/.unicorn-binance-suite/

### DIFF
--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -31,6 +31,8 @@ import sys
 import kubernetes
 import time
 import traceback
+from pathlib import Path
+
 from fastapi import FastAPI
 
 
@@ -351,8 +353,10 @@ class App:
         # Logging
         if self.logger is None:
             self.logger = logging.getLogger("unicorn_binance_depthcache_cluster")
+            ubs_logs = os.path.join(str(Path.home()), ".unicorn-binance-suite", "logs")
+            os.makedirs(ubs_logs, exist_ok=True)
             logging.basicConfig(level=logging.DEBUG,
-                                filename=f"{socket.gethostname()}.log",
+                                filename=os.path.join(ubs_logs, f"ubdcc-{socket.gethostname()}.log"),
                                 format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                                 style="{")
 

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -24,16 +24,21 @@ import socket
 import subprocess
 import sys
 import time
+from pathlib import Path
 
 import requests
 
 from ubdcc import __version__
 
-STATE_FILE = ".ubdcc"
+UBS_BASE = os.path.join(str(Path.home()), ".unicorn-binance-suite")
+UBS_CONFIG = os.path.join(UBS_BASE, "config")
+UBS_LOGS = os.path.join(UBS_BASE, "logs")
+STATE_FILE = os.path.join(UBS_CONFIG, "ubdcc.state")
 DEFAULT_MGMT_PORT = 42080
 
 
 def save_port(port):
+    os.makedirs(UBS_CONFIG, exist_ok=True)
     with open(STATE_FILE, "w") as f:
         f.write(str(port))
 
@@ -42,6 +47,15 @@ def load_port():
     try:
         with open(STATE_FILE, "r") as f:
             return int(f.read().strip())
+    except (FileNotFoundError, ValueError):
+        pass
+    # Legacy fallback: check CWD
+    try:
+        with open(".ubdcc", "r") as f:
+            port = int(f.read().strip())
+            print(f"WARNING: Loading state from deprecated path `.ubdcc` in CWD. "
+                  f"State is now stored in `{STATE_FILE}`.")
+            return port
     except (FileNotFoundError, ValueError):
         return None
 
@@ -93,7 +107,7 @@ def wait_for_cluster(mgmt_port, expected_pods, timeout=120):
 def cmd_start(args):
     mgmt_port = args.port if args.port else find_free_port(DEFAULT_MGMT_PORT)
     dcn_count = args.dcn
-    logdir = args.logdir if args.logdir else os.getcwd()
+    logdir = args.logdir if args.logdir else UBS_LOGS
     os.makedirs(logdir, exist_ok=True)
     save_port(mgmt_port)
 


### PR DESCRIPTION
## Summary

- State file moved from `.ubdcc` in CWD to `~/.unicorn-binance-suite/config/ubdcc.state`
- Log files moved from CWD to `~/.unicorn-binance-suite/logs/` (CLI logs prefixed `ubdcc-`, shared-modules logs prefixed `ubdcc-<hostname>`)
- Legacy `.ubdcc` file in CWD still supported with deprecation warning
- Directories are created automatically via `os.makedirs(..., exist_ok=True)`

## Changed files

- `packages/ubdcc/ubdcc/cli.py` — new path constants, `save_port` creates config dir, `load_port` with legacy fallback, logdir default changed
- `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py` — log file written to `~/.unicorn-binance-suite/logs/ubdcc-<hostname>.log`

## Test plan

- [ ] `ubdcc start` creates `~/.unicorn-binance-suite/config/ubdcc.state` and logs in `~/.unicorn-binance-suite/logs/`
- [ ] Legacy `.ubdcc` in CWD is picked up with deprecation warning when new state file doesn't exist
- [ ] `--logdir` flag still overrides default log directory