### PR TITLE
SECURITY.md: switch contact URL to GitHub Security Advisories

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ This document outlines security procedures and general policies for the
 Thank you for improving the security of `unicorn-binance-depth-cache-cluster`. We appreciate your 
 efforts and responsible disclosure and will make every effort to acknowledge your contributions.
 
-Report security bugs via our contact form: 
-https://about.me/oliver-zehentleitner/contact-unicorn-developers.html
+Please report security bugs privately via GitHub Security Advisories:
+https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/security/advisories/new
 
 The lead maintainer will acknowledge your email within 48 hours, and will send a
 more detailed response within 48 hours indicating the next steps in handling


### PR DESCRIPTION
The old `about.me/oliver-zehentleitner/contact-unicorn-developers.html` URL is broken (about.me doesn't host that path). Switched to the same pattern used across the rest of the UBS repos:

`https://github.com/oliver-zehentleitner/<repo>/security/advisories/new`