### PR TITLE
Cross-link AGENTS.md and llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # AGENTS.md — UNICORN Binance DepthCache Cluster
 
+> **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this cluster.
+> **This file** is for AI agents working *on* this repo itself.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.

--- a/llms.txt
+++ b/llms.txt
@@ -85,6 +85,7 @@ Runs as processes on a single machine or as pods on Kubernetes.
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster
+- AGENTS.md (for AI agents working on this repo): https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/AGENTS.md
 - Docs: https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster
 - PyPI: https://pypi.org/project/ubdcc/ (meta package; also `ubdcc-mgmt`, `ubdcc-dcn`, `ubdcc-restapi`, `ubdcc-shared-modules`)
 - Changelog: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/blob/master/CHANGELOG.md


### PR DESCRIPTION
Two AI-facing files, two audiences:

- `llms.txt` = cheat sheet for LLMs writing code **against** this library
- `AGENTS.md` = briefing for AI agents working **on** this repo

Adding explicit cross-links at the top of `AGENTS.md` and in the Docs block of `llms.txt` so either file points at the other.