### PR TITLE
Document interactive API docs (Swagger UI, ReDoc, OpenAPI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,16 @@ The REST API (default port **42081** locally, port **80** on Kubernetes) is your
 On Kubernetes, a LoadBalancer service distributes requests across restapi pods automatically. Locally, you connect 
 directly to one restapi instance — it handles all routing to mgmt and DCN processes internally.
 
+### Interactive API docs
+
+When running locally (dev mode), the restapi exposes FastAPI's built-in interactive documentation:
+
+- Swagger UI: [http://127.0.0.1:42081/docs](http://127.0.0.1:42081/docs)
+- ReDoc: [http://127.0.0.1:42081/redoc](http://127.0.0.1:42081/redoc)
+- OpenAPI schema: [http://127.0.0.1:42081/openapi.json](http://127.0.0.1:42081/openapi.json)
+
+These endpoints are disabled in productive mode (Kubernetes).
+
 ### Public Endpoints (restapi)
 
 These are the endpoints you use to interact with the cluster. All requests go through the restapi.

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -311,6 +311,16 @@ The REST API (default port **42081** locally, port **80** on Kubernetes) is your
 On Kubernetes, a LoadBalancer service distributes requests across restapi pods automatically. Locally, you connect 
 directly to one restapi instance — it handles all routing to mgmt and DCN processes internally.
 
+### Interactive API docs
+
+When running locally (dev mode), the restapi exposes FastAPI's built-in interactive documentation:
+
+- Swagger UI: [http://127.0.0.1:42081/docs](http://127.0.0.1:42081/docs)
+- ReDoc: [http://127.0.0.1:42081/redoc](http://127.0.0.1:42081/redoc)
+- OpenAPI schema: [http://127.0.0.1:42081/openapi.json](http://127.0.0.1:42081/openapi.json)
+
+These endpoints are disabled in productive mode (Kubernetes).
+
 ### Public Endpoints (restapi)
 
 These are the endpoints you use to interact with the cluster. All requests go through the restapi.


### PR DESCRIPTION
## Summary
- Add a new **Interactive API docs** section to the REST API chapter of the README.
- Links to Swagger UI (`/docs`), ReDoc (`/redoc`) and the OpenAPI schema (`/openapi.json`) on the local dev port 42081.
- Clarifies that these endpoints are only available in dev mode (disabled in productive/K8s via `docs_url=None, redoc_url=None`).

Applied to both `README.md` and `dev/sphinx/source/readme.md`.

## Test plan
- [ ] Verify rendered README on GitHub (new section appears between REST API intro and "Public Endpoints").
- [ ] Rebuild Sphinx docs and confirm the section renders in `docs/readme.html`.
- [ ] Start cluster locally (`ubdcc start`) and open `http://127.0.0.1:42081/docs` to confirm the link works.