### PR TITLE
docs: render ubdcc CLI reference via sphinxcontrib-autoprogram

### DIFF
--- a/dev/sphinx/install_sphinx.sh
+++ b/dev/sphinx/install_sphinx.sh
@@ -5,3 +5,4 @@ python3 -m pip install rich --upgrade
 python3 -m pip install myst-parser --upgrade
 python3 -m pip install sphinx-markdown-tables --upgrade
 python3 -m pip install sphinxcontrib-mermaid --upgrade
+python3 -m pip install sphinxcontrib-autoprogram --upgrade

--- a/dev/sphinx/source/conf.py
+++ b/dev/sphinx/source/conf.py
@@ -16,6 +16,7 @@
 import os
 import sys
 
+sys.path.insert(0, os.path.abspath('../../../packages/ubdcc/'))
 sys.path.insert(0, os.path.abspath('../../../packages/ubdcc-dcn/'))
 sys.path.insert(0, os.path.abspath('../../../packages/ubdcc-mgmt/'))
 sys.path.insert(0, os.path.abspath('../../../packages/ubdcc-restapi/'))
@@ -52,7 +53,10 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinxcontrib.mermaid',
+    'sphinxcontrib.autoprogram',
 ]
+
+autodoc_mock_imports = ['requests']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/dev/sphinx/source/ubdcc.rst
+++ b/dev/sphinx/source/ubdcc.rst
@@ -1,13 +1,10 @@
-ubdcc package
-=============
+ubdcc CLI
+=========
 
-Submodules
-----------
+The ``ubdcc`` command-line interface manages a local UBDCC cluster (start,
+status, stop, credentials). See the ``start`` subcommand for the interactive
+shell commands available at runtime (``add-dcn``, ``remove-dcn``, ``status``,
+``restart``, ``stop``, ``help``).
 
-Module contents
----------------
-
-.. automodule:: ubdcc
-   :members:
-   :undoc-members:
-   :show-inheritance:
+.. autoprogram:: ubdcc.cli:build_parser()
+   :prog: ubdcc

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -569,7 +569,7 @@ def cmd_credentials_list(args):
         print(f"{c['id']}  {c['account_group']:<32}  {preview}  assigned=[{assigned}]")  # lgtm[py/clear-text-logging-sensitive-data]
 
 
-def main():
+def build_parser():
     parser = argparse.ArgumentParser(
         prog='ubdcc',
         description='UNICORN Binance DepthCache Cluster — Cluster Manager\n'
@@ -620,6 +620,11 @@ def main():
     cred_list = cred_sub.add_parser('list', help='List configured credentials (keys masked)')
     cred_list.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080)')
 
+    return parser
+
+
+def main():
+    parser = build_parser()
     args = parser.parse_args()
 
     if args.command == 'start':
@@ -636,7 +641,7 @@ def main():
         elif args.cred_command == 'list':
             cmd_credentials_list(args)
         else:
-            cred_parser.print_help()
+            parser.parse_args(['credentials', '--help'])
     else:
         parser.print_help()
 


### PR DESCRIPTION
## Summary
- The \`ubdcc\` package is a CLI wrapper — \`__init__.py\` only exposes \`__version__\`, so \`automodule:: ubdcc\` rendered an empty page.
- Extract the argparse parser into \`ubdcc.cli.build_parser()\` so \`sphinxcontrib-autoprogram\` can introspect it. No CLI behaviour or \`--help\` output changes.
- Wire up the autoprogram extension in \`conf.py\` + install script, add \`packages/ubdcc/\` to \`sys.path\`, and mock the runtime-only \`requests\` import during doc builds.
- Rewrite \`ubdcc.rst\` to render the full CLI (\`start\`, \`status\`, \`stop\`, \`credentials add/remove/list\`) from the parser definition.

## Test plan
- [x] \`build_parser()\` returns a valid ArgumentParser; subcommands and \`--help\` output match the previous inline definition
- [ ] Run \`dev/sphinx/install_sphinx.sh\` and rebuild the docs locally — verify \`ubdcc.html\` now shows the CLI reference
- [ ] Regenerate \`docs/\` (committed artifacts) before release if this goes in