### PR TITLE
CLI: show DC restarts in status, list credentials subcommands in --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.5.0.dev (development stage/unreleased/unstable)
+### Added
+- CLI `status`: new "DC restarts" section lists every depth cache whose
+  WebSocket stream has been restarted at least once, sorted by restart
+  count descending, with a human-readable "last restart" timestamp
+  (e.g. `45s ago`, `2h ago`). Hidden when no DC has restarted.
+- CLI `--help`: the top-level help now lists the `credentials`
+  subcommands (`add`, `remove`, `list`) in the epilog alongside the
+  interactive shell commands, so users no longer need to run
+  `ubdcc credentials --help` to discover them.
 
 ## 0.5.0
 ### Added

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.5.0.dev (development stage/unreleased/unstable)
+### Added
+- CLI `status`: new "DC restarts" section lists every depth cache whose
+  WebSocket stream has been restarted at least once, sorted by restart
+  count descending, with a human-readable "last restart" timestamp
+  (e.g. `45s ago`, `2h ago`). Hidden when no DC has restarted.
+- CLI `--help`: the top-level help now lists the `credentials`
+  subcommands (`add`, `remove`, `list`) in the epilog alongside the
+  interactive shell commands, so users no longer need to run
+  `ubdcc credentials --help` to discover them.
 
 ## 0.5.0
 ### Added

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -510,6 +510,34 @@ def print_status_table(data, mgmt_port=42080):
     print(f"\nDepthCaches: {dc_count} ({total_replicas} replicas: {replicas_running} running, {replicas_starting} starting)")
     print(f"Redundancy: {fully_redundant} fully redundant, {degraded} degraded, {no_redundancy} no redundancy")
     print(f"Version: {data.get('version', '?')}")
+
+    dc_restarts = []
+    for exchange, markets in depthcaches.items():
+        for market, dc in markets.items():
+            distribution = dc.get('DISTRIBUTION', {}).values()
+            restarts = sum(d.get('RESTARTS', 0) for d in distribution)
+            last = max((d.get('LAST_RESTART_TIME', 0) for d in distribution), default=0)
+            if restarts > 0:
+                dc_restarts.append((exchange, market, restarts, last))
+    if dc_restarts:
+        now = time.time()
+        print(f"\n{'EXCHANGE':<28} {'MARKET':<16} {'RESTARTS':>8}  LAST RESTART")
+        print("-" * 70)
+        for exchange, market, restarts, last in sorted(dc_restarts, key=lambda x: -x[2]):
+            if last > 0:
+                delta = max(0, int(now - last))
+                if delta < 60:
+                    ago = f"{delta}s ago"
+                elif delta < 3600:
+                    ago = f"{delta // 60}min ago"
+                elif delta < 86400:
+                    ago = f"{delta // 3600}h ago"
+                else:
+                    ago = f"{delta // 86400}d ago"
+            else:
+                ago = "-"
+            print(f"{exchange:<28} {market:<16} {restarts:>8}  {ago}")
+
     if restapi_port:
         print(f"\nREST API: http://127.0.0.1:{restapi_port}/")
         print(f"Cluster info: http://127.0.0.1:{restapi_port}/get_cluster_info")
@@ -574,7 +602,12 @@ def build_parser():
         prog='ubdcc',
         description='UNICORN Binance DepthCache Cluster — Cluster Manager\n'
                     'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster',
-        epilog='Interactive shell commands (available inside "ubdcc start"):\n'
+        epilog='Credentials subcommands (use "ubdcc credentials <cmd> --help" for details):\n'
+               '  credentials add       Add a Binance API key/secret\n'
+               '  credentials remove    Remove credentials by id\n'
+               '  credentials list      List configured credentials (keys masked)\n'
+               '\n'
+               'Interactive shell commands (available inside "ubdcc start"):\n'
                '  add-dcn [count]       Spawn new DCN process(es)\n'
                '  remove-dcn <count|name> Stop and remove DCN(s)\n'
                '  status                Show cluster status\n'


### PR DESCRIPTION
## Summary
Two CLI UX fixes in the \`ubdcc\` package:

**1. \`ubdcc status\`: show DC restarts**
New block after the redundancy summary: every depth cache whose WebSocket stream has restarted at least once, sum of \`RESTARTS\` across all replicas, sorted by count descending, with a human-readable \"last restart\" timestamp (\`45s ago\`, \`2h ago\`, \`3d ago\`). Hidden when no DC has restarted (no clutter on fresh clusters).

**2. Top-level \`ubdcc --help\`: list credentials subcommands**
The epilog now includes a \"Credentials subcommands\" block next to the existing \"Interactive shell commands\" block, so users see \`credentials add / remove / list\` without having to run \`ubdcc credentials --help\` first.

## Test plan
- [x] \`ubdcc --help\` lists \`credentials add/remove/list\` in epilog
- [x] \`ubdcc credentials --help\` still shows the full detail (unchanged)
- [x] \`print_status_table\` with synthetic restart data renders the new block correctly
- [x] \`print_status_table\` with a fresh cluster (0 restarts everywhere) hides the new block
- [ ] Manual verification via \`ubdcc status\` against a real cluster once a DC has restarted at least once

## Notes
- Only touched the root CHANGELOG (+ sphinx mirror). \`packages/ubdcc/CHANGELOG.md\` still reads \`0.4.0.dev\` even though the package is on 0.5.0 — left that alone, looks like a separate housekeeping bump.