### PR TITLE
mgmt: forward last_restart_time to DB so RESTARTS counter actually increments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   subcommands (`add`, `remove`, `list`) in the epilog alongside the
   interactive shell commands, so users no longer need to run
   `ubdcc credentials --help` to discover them.
+### Fixed
+- mgmt `/ubdcc_update_depthcache_distribution`: `last_restart_time`
+  was parsed from the query string but never forwarded to
+  `Database.update_depthcache_distribution()` — so the `RESTARTS`
+  counter per DC distribution entry stayed at 0 forever, no matter how
+  often a UBLDC stream restarted. Also: the query param arrived as a
+  string but the DB expected a float, so the subsequent `!=` compare
+  against the stored value would have been string-vs-float. Both are
+  fixed now: cast to `float` with an explicit error response (`#1024`)
+  on malformed input, and pass the value through to the DB call.
 
 ## 0.5.0
 ### Added

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -19,6 +19,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   subcommands (`add`, `remove`, `list`) in the epilog alongside the
   interactive shell commands, so users no longer need to run
   `ubdcc credentials --help` to discover them.
+### Fixed
+- mgmt `/ubdcc_update_depthcache_distribution`: `last_restart_time`
+  was parsed from the query string but never forwarded to
+  `Database.update_depthcache_distribution()` — so the `RESTARTS`
+  counter per DC distribution entry stayed at 0 forever, no matter how
+  often a UBLDC stream restarted. Also: the query param arrived as a
+  string but the DB expected a float, so the subsequent `!=` compare
+  against the stored value would have been string-vs-float. Both are
+  fixed now: cast to `float` with an explicit error response (`#1024`)
+  on malformed input, and pass the value through to the DB call.
 
 ## 0.5.0
 ### Added

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -528,6 +528,13 @@ class RestEndpoints(RestEndpointsBase):
             pod_uid = None
         if last_restart_time == "None":
             last_restart_time = None
+        elif last_restart_time is not None:
+            try:
+                last_restart_time = float(last_restart_time)
+            except (TypeError, ValueError):
+                return self.get_error_response(event=event, error_id="#1024",
+                                               message=f"Invalid last_restart_time value: "
+                                                       f"{last_restart_time!r}")
         if status == "None":
             status = None
         if exchange is None or market is None or pod_uid is None:
@@ -537,7 +544,9 @@ class RestEndpoints(RestEndpointsBase):
             return self.get_error_response(event=event, error_id="#1022",
                                            message="Nothing to update! Missing parameter: last_restart_time, status")
         result = self.db.update_depthcache_distribution(exchange=exchange, market=market,
-                                                        pod_uid=pod_uid, status=status)
+                                                        pod_uid=pod_uid,
+                                                        last_restart_time=last_restart_time,
+                                                        status=status)
         if result is True:
             return self.get_ok_response(event=event)
         else:


### PR DESCRIPTION
## Summary
Bugfix found while investigating why a 24h-old cluster with 23 depth caches reported \`RESTARTS: 0\` everywhere, despite Binance regularly dropping WebSocket streams.

Root cause: \`/ubdcc_update_depthcache_distribution\` in \`packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py\` reads \`last_restart_time\` from the query string and does \"None\"→\`None\` normalization, but then builds the DB call **without** the \`last_restart_time=\` kwarg:

\`\`\`python
# before
result = self.db.update_depthcache_distribution(exchange=exchange, market=market,
                                                pod_uid=pod_uid, status=status)
\`\`\`

So \`Database.update_depthcache_distribution()\` never saw the value, never entered the branch that increments \`RESTARTS\` and writes \`LAST_RESTART_TIME\`. The per-distribution counter was permanently stuck at 0.

Secondary issue: even if it had been forwarded, the query param is a string (\`\"1776767531.23\"\`), while the DB expects a float. The downstream \`if last_restart_time != dist.get('LAST_RESTART_TIME'):\` compare would have been string-vs-float — technically always \`True\`, which hides the bug but gives us a string in the DB.

## Fix
- Explicit \`float\` cast with error response (\`#1024\`) on malformed input.
- Pass \`last_restart_time\` through to the DB call.

## Test plan
- [ ] After merge + cluster restart: run a cluster for a few hours, check \`get_cluster_info\` — \`RESTARTS\` should now show >0 for streams that disconnected at least once
- [ ] \`ubdcc status\` (with #124 merged) should then list those DCs in the new "DC restarts" block

## Related
- Depends-on-nothing but pairs naturally with #124 (CLI restart display) — without this fix, the CLI block would stay empty forever.