### PR TITLE
credentials: event-driven rebalance + hot-swap propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   subcommands (`add`, `remove`, `list`) in the epilog alongside the
   interactive shell commands, so users no longer need to run
   `ubdcc credentials --help` to discover them.
+### Changed
+- Credential assignment is now **event-driven and self-healing**.
+  Previously, a DCN pulled its API key exactly once (on the first
+  depth cache it created for a given exchange) and cached the result —
+  including a sticky `None` after any transient failure, leaving
+  `assigned_dcns: []` forever across cluster restarts. Now:
+  - `Database.rebalance_account_group()` redistributes every active DCN
+    round-robin across the credentials available for that account
+    group. It runs on `add_credentials()` / `delete_credentials()` and
+    as part of `revise()` when the DCN population changes.
+  - DCNs cache only the `credential_id` per account group as a
+    comparison reference. On every main-loop tick they ask mgmt for
+    their current assignment and, when the id differs, hot-swap the
+    UBRA in every affected `BinanceLocalDepthCacheManager` via the
+    new `set_credentials()` public API (requires UBLDC ≥ 2.13.0).
+    WebSocket streams keep running; new credentials take effect from
+    the next REST call (snapshot / resync).
+- `packages/ubdcc-dcn`: bumped `unicorn-binance-local-depth-cache`
+  minimum to `>=2.13.0` across `setup.py`, `requirements.txt` and
+  `pyproject.toml` for the `set_credentials()` method.
 ### Fixed
 - mgmt `/ubdcc_update_depthcache_distribution`: `last_restart_time`
   was parsed from the query string but never forwarded to

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -19,6 +19,26 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   subcommands (`add`, `remove`, `list`) in the epilog alongside the
   interactive shell commands, so users no longer need to run
   `ubdcc credentials --help` to discover them.
+### Changed
+- Credential assignment is now **event-driven and self-healing**.
+  Previously, a DCN pulled its API key exactly once (on the first
+  depth cache it created for a given exchange) and cached the result —
+  including a sticky `None` after any transient failure, leaving
+  `assigned_dcns: []` forever across cluster restarts. Now:
+  - `Database.rebalance_account_group()` redistributes every active DCN
+    round-robin across the credentials available for that account
+    group. It runs on `add_credentials()` / `delete_credentials()` and
+    as part of `revise()` when the DCN population changes.
+  - DCNs cache only the `credential_id` per account group as a
+    comparison reference. On every main-loop tick they ask mgmt for
+    their current assignment and, when the id differs, hot-swap the
+    UBRA in every affected `BinanceLocalDepthCacheManager` via the
+    new `set_credentials()` public API (requires UBLDC ≥ 2.13.0).
+    WebSocket streams keep running; new credentials take effect from
+    the next REST call (snapshot / resync).
+- `packages/ubdcc-dcn`: bumped `unicorn-binance-local-depth-cache`
+  minimum to `>=2.13.0` across `setup.py`, `requirements.txt` and
+  `pyproject.toml` for the `set_credentials()` method.
 ### Fixed
 - mgmt `/ubdcc_update_depthcache_distribution`: `last_restart_time`
   was parsed from the query string but never forwarded to

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 [tool.poetry.dependencies]
 python = ">=3.9.0"
 ubdcc-shared-modules = "==0.5.0"
-unicorn_binance_local_depth_cache = ">=2.12.0"
+unicorn_binance_local_depth_cache = ">=2.13.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-dcn/requirements.txt
+++ b/packages/ubdcc-dcn/requirements.txt
@@ -1,2 +1,2 @@
 ubdcc-shared-modules==0.5.0
-unicorn-binance-local-depth-cache>=2.11.0
+unicorn-binance-local-depth-cache>=2.13.0

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type="text/markdown",
     license='MIT',
     install_requires=['ubdcc-shared-modules==0.5.0',
-                      'unicorn-binance-local-depth-cache>=2.12.0'],
+                      'unicorn-binance-local-depth-cache>=2.13.0'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -26,11 +26,6 @@ from ubdcc_shared_modules.ServiceBase import ServiceBase
 from unicorn_binance_local_depth_cache import BinanceLocalDepthCacheManager, DepthCacheNotFound
 from unicorn_binance_local_depth_cache.manager import __version__ as ubldc_version
 
-try:
-    from unicorn_binance_rest_api import BinanceRestApiManager
-except ImportError:
-    BinanceRestApiManager = None
-
 
 class DepthCacheNode(ServiceBase):
     def __init__(self, cwd=None, mgmt_port=None):
@@ -47,43 +42,53 @@ class DepthCacheNode(ServiceBase):
         """Thread-safe: invoked from UBLDC's manager thread on every stream restart."""
         self._restart_queue.put((exchange, market, timestamp))
 
-    async def _get_ubra_manager(self, exchange: str):
-        """Return a BinanceRestApiManager for `exchange` with assigned API
-        credentials, or None when no credentials are configured for that
-        account_group (UBLDC then falls back to public rate limits)."""
-        if BinanceRestApiManager is None:
-            return None
-        account_group = get_account_group(exchange)
-        if account_group is None:
-            return None
-        cache = self.app.data.setdefault('ubra_by_account_group', {})
-        if account_group in cache:
-            return cache[account_group]
-        credential = await self.app.ubdcc_assign_credentials(account_group=account_group)
-        if credential is None:
-            cache[account_group] = None
-            return None
-        try:
-            ubra = BinanceRestApiManager(api_key=credential['api_key'],
-                                         api_secret=credential['api_secret'],
-                                         exchange=exchange,
-                                         disable_colorama=True,
-                                         warn_on_update=False)
-        except Exception as error_msg:
-            self.app.stdout_msg(f"Could not create BinanceRestApiManager for '{account_group}': {error_msg}",
-                                log="error")
-            cache[account_group] = None
-            return None
-        self.app.stdout_msg(f"Assigned credential '{credential['id']}' for account_group "
-                            f"'{account_group}'.", log="info")
-        cache[account_group] = ubra
-        return ubra
+    def _ldcs_for_account_group(self, account_group: str):
+        """Yield every running BinanceLocalDepthCacheManager whose exchange maps
+        to the given account_group."""
+        for exchange, by_interval in self.app.data.get('depthcache_instances', {}).items():
+            if get_account_group(exchange) != account_group:
+                continue
+            for ldc in by_interval.values():
+                if ldc is not None:
+                    yield ldc
+
+    async def _sync_credentials(self) -> None:
+        """For every account_group currently used by this DCN, pull the assigned
+        credential from mgmt. If the credential id differs from the one we last
+        propagated, hot-swap the UBRA in all affected UBLDCs via
+        `set_credentials()`. Runs once per main-loop iteration after the
+        mgmt sync."""
+        cache = self.app.data['credential_id_by_account_group']
+        used_account_groups = {get_account_group(exch)
+                               for exch in self.app.data.get('depthcache_instances', {})}
+        used_account_groups.discard(None)
+        for account_group in used_account_groups:
+            credential = await self.app.ubdcc_assign_credentials(account_group=account_group)
+            new_id = credential.get('id') if credential else None
+            if cache.get(account_group) == new_id:
+                continue
+            api_key = credential.get('api_key') if credential else None
+            api_secret = credential.get('api_secret') if credential else None
+            for ldc in self._ldcs_for_account_group(account_group):
+                try:
+                    ldc.set_credentials(api_key=api_key, api_secret=api_secret)
+                except Exception as error_msg:
+                    self.app.stdout_msg(f"set_credentials() failed for '{account_group}': "
+                                        f"{error_msg}", log="error")
+            cache[account_group] = new_id
+            if new_id is not None:
+                self.app.stdout_msg(f"Assigned credential '{new_id}' for account_group "
+                                    f"'{account_group}'.", log="info")
+            else:
+                self.app.stdout_msg(f"No credential available for account_group "
+                                    f"'{account_group}' — using public rate limits.",
+                                    log="info")
 
     async def main(self):
         self.app.data['depthcache_instances'] = {}
         self.app.data['local_depthcaches'] = []
         self.app.data['responsibilities'] = []
-        self.app.data['ubra_by_account_group'] = {}
+        self.app.data['credential_id_by_account_group'] = {}
         await self.start_rest_server(endpoints=RestEndpoints)
         self.app.set_status_running()
         await self.app.register_or_restart(ubldc_version=ubldc_version)
@@ -92,6 +97,7 @@ class DepthCacheNode(ServiceBase):
             await self.app.sleep()
             await self.app.ubdcc_node_sync()
             await self._drain_restart_queue()
+            await self._sync_credentials()
             self.app.data['responsibilities'] = self.db.get_dcn_responsibilities()
             self.app.stdout_msg(f"Local DepthCaches: {self.app.data['local_depthcaches']}", log="debug", stdout=False)
             self.app.stdout_msg(f"Responsibilities: {self.app.data['responsibilities']}", log="debug", stdout=False)
@@ -105,14 +111,16 @@ class DepthCacheNode(ServiceBase):
                         self.app.data['depthcache_instances'][dc['exchange']] = {}
                     if self.app.data['depthcache_instances'][dc['exchange']].get(dc['update_interval']) is None:
                         on_restart = partial(self._on_stream_restart, dc['exchange'])
-                        ubra_manager = await self._get_ubra_manager(exchange=dc['exchange'])
                         kwargs = {"exchange": dc['exchange'], "on_restart": on_restart}
                         if dc['update_interval'] is not None:
                             kwargs['depth_cache_update_interval'] = dc['update_interval']
-                        if ubra_manager is not None:
-                            kwargs['ubra_manager'] = ubra_manager
+                        # The UBRA is managed by UBLDC itself (no ubra_manager
+                        # kwarg); credentials are propagated immediately below
+                        # so the initial snapshot already runs with an
+                        # authenticated key when one is assigned.
                         self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']] = \
                             BinanceLocalDepthCacheManager(**kwargs)
+                        await self._sync_credentials()
                     else:
                         self.app.data['depthcache_instances'][dc['exchange']][dc['update_interval']].create_depthcache(
                             markets=dc['market'],

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/Database.py
@@ -152,7 +152,39 @@ class Database:
                 self.data['credentials'] = {}
             self.data['credentials'][credential_id] = credential
             self._set_update_timestamp()
+        self.rebalance_account_group(account_group)
         return credential_id
+
+    def rebalance_account_group(self, account_group: str = None) -> bool:
+        """Redistribute all active DCN uids evenly (round-robin) over the
+        credentials available for this account_group. Called whenever the
+        credential set or the DCN population for this group changes. Returns
+        True when the assignment actually changed."""
+        if account_group is None:
+            raise ValueError("Missing mandatory parameter: account_group")
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            candidates = [c for c in credentials.values()
+                          if c['ACCOUNT_GROUP'] == account_group]
+            dcn_uids = sorted(uid for uid, pod in self.data.get('pods', {}).items()
+                              if pod.get('ROLE') == "ubdcc-dcn")
+            before = {c['ID']: list(c['ASSIGNED_DCNS']) for c in candidates}
+            if not candidates:
+                # no keys for this group — nothing to do (the credentials dict
+                # is empty for this group anyway)
+                return False
+            for c in candidates:
+                c['ASSIGNED_DCNS'] = []
+            for i, uid in enumerate(dcn_uids):
+                candidates[i % len(candidates)]['ASSIGNED_DCNS'].append(uid)
+            after = {c['ID']: list(c['ASSIGNED_DCNS']) for c in candidates}
+            if before != after:
+                self._set_update_timestamp()
+                self.app.stdout_msg(f"Rebalanced credentials for '{account_group}': "
+                                    f"{len(dcn_uids)} DCN(s) over {len(candidates)} key(s)",
+                                    log="info")
+                return True
+            return False
 
     def assign_credentials(self, uid: str = None, account_group: str = None) -> dict | None:
         """Assign (or return already-assigned) credential to a DCN uid.
@@ -184,8 +216,10 @@ class Database:
             credentials = self.data.get('credentials') or {}
             if credential_id not in credentials:
                 return False
+            account_group = credentials[credential_id]['ACCOUNT_GROUP']
             del credentials[credential_id]
             self._set_update_timestamp()
+        self.rebalance_account_group(account_group)
         return True
 
     def get_credentials(self, credential_id: str = None) -> dict | None:
@@ -458,10 +492,30 @@ class Database:
         self.delete_old_pods()
         self.remove_orphaned_distribution_entries()
         self.remove_orphaned_credential_assignments()
+        self.rebalance_credential_assignments_if_needed()
         self.manage_distribution()
         run_time = time.time() - start_time
         self.app.stdout_msg(f"Database revised in {run_time} seconds!", log="info")
         return True
+
+    def rebalance_credential_assignments_if_needed(self) -> bool:
+        """Detect DCN-population changes since the last revise() and rebalance
+        affected account_groups. Keeps every active DCN exactly one assigned
+        credential per account_group (or none if no key is configured)."""
+        with self.data_lock:
+            credentials = self.data.get('credentials') or {}
+            current_dcns = {uid for uid, pod in self.data.get('pods', {}).items()
+                            if pod.get('ROLE') == "ubdcc-dcn"}
+            groups_with_creds = {c['ACCOUNT_GROUP'] for c in credentials.values()}
+            assigned_by_group: dict[str, set[str]] = {g: set() for g in groups_with_creds}
+            for c in credentials.values():
+                assigned_by_group[c['ACCOUNT_GROUP']].update(c['ASSIGNED_DCNS'])
+        changed = False
+        for group in groups_with_creds:
+            if assigned_by_group[group] != current_dcns:
+                if self.rebalance_account_group(account_group=group):
+                    changed = True
+        return changed
 
     def manage_distribution(self) -> bool:
         add_distributions = []


### PR DESCRIPTION
## The underlying bug
DCNs pulled their API key exactly once — on the first depth cache they created for an exchange — and cached the result. Any transient \`None\` (mgmt race, stale replica, empty keyring at that instant) became sticky for the whole DCN lifetime. Meanwhile \`remove_orphaned_credential_assignments()\` kept purging the old uids every \`revise()\` tick, because the new DCN process has a fresh uid. Net effect: \`assigned_dcns: []\` stayed empty for 24h+ on a running cluster with live keys and live DCNs.

## New model

**mgmt (shared_modules/Database.py)**
- New \`rebalance_account_group(account_group)\` — round-robins every active DCN uid (\`ROLE=ubdcc-dcn\`) across the credentials available for that account group.
- Triggered from:
  - \`add_credentials()\` — fold the new key into the distribution
  - \`delete_credentials()\` — redistribute orphaned DCNs onto the remaining keys (or clear all \`ASSIGNED_DCNS\` if it was the last key for that group)
  - \`revise()\` via the new \`rebalance_credential_assignments_if_needed()\` — detects DCN-population changes (register / unregister) by comparing the union of \`ASSIGNED_DCNS\` against the current DCN pod set
- \`assign_credentials()\` keeps its existing idempotent lookup semantics — it's the pull endpoint DCNs use.

**DCN (ubdcc-dcn/DepthCacheNode.py)**
- \`_get_ubra_manager\` + \`ubra_by_account_group\` cache gone. The DCN no longer constructs UBRAs.
- Replaced by \`_sync_credentials()\`, called each main-loop tick:
  - For every account group currently in use by this DCN, pull the assigned credential from mgmt via the existing \`/ubdcc_assign_credentials\` endpoint
  - Compare the \`credential_id\` to \`credential_id_by_account_group[ag]\` (plain string cache, not UBRA)
  - On a diff, hot-swap via \`ldc.set_credentials(api_key, api_secret)\` on every affected \`BinanceLocalDepthCacheManager\` — WebSocket streams keep running; new credentials take effect from the next REST call (snapshot / resync)
- Also runs immediately after a fresh \`BinanceLocalDepthCacheManager\` is constructed, so the initial snapshot already uses the assigned key when one is available.
- Sticky-\`None\` gone: the new cache stores only the \`credential_id\`. If it's \`None\`, the next tick simply asks again.
- Bumped UBLDC dep to \`>=2.13.0\` in \`setup.py\`, \`requirements.txt\`, \`pyproject.toml\` — that's the version shipping \`set_credentials()\`.

Legacy \`release_credentials()\` (unused in the existing codebase) untouched.

## Test plan
- [x] Syntax clean (\`py_compile\` on both touched modules)
- [x] Mgmt stub test: add 1 key / 3 DCNs → all assigned to the one key; add 2nd key → 2+1 split; add testnet key → independent rebalance; delete 1st key → remaining key gets all 3; remove a DCN → rebalance; delete last key of a group → \`ASSIGNED_DCNS\` cleared for that group, other groups untouched
- [ ] Live cluster: add a key → watch \`get_cluster_info\` for \`assigned_dcns\` populating within one revise tick
- [ ] Live cluster: delete a key → watch \`assigned_dcns\` rebalance onto the remaining keys
- [ ] Live cluster: restart a DCN → new uid should appear in \`assigned_dcns\` within one revise tick

## Follow-up (optional)
- \`release_credentials()\` is now formally dead code — could be removed in a cleanup PR if you want.