### PR TITLE
package changelogs: fill 0.5.0 and 0.6.0 blocks

### DIFF
--- a/packages/ubdcc-dcn/CHANGELOG.md
+++ b/packages/ubdcc-dcn/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this package will be documented in this file.
 ## 0.6.0.dev (development stage/unreleased/unstable)
 
 ## 0.6.0
+### Changed
+- Credential handling moved from DCN-controlled to UBLDC-controlled.
+  The DCN no longer constructs a `BinanceRestApiManager` itself —
+  it only keeps a `credential_id_by_account_group` cache as a
+  comparison reference. On every main-loop tick (and immediately
+  after creating a fresh `BinanceLocalDepthCacheManager`),
+  `_sync_credentials()` asks mgmt for the current assignment per
+  used account group and, on an id diff, hot-swaps the UBRA inside
+  every affected `BinanceLocalDepthCacheManager` via
+  `ldc.set_credentials(api_key, api_secret)`. WebSocket streams keep
+  running; new credentials take effect from the next REST call
+  (initial snapshot / resync). Eliminates the previous "sticky `None`"
+  cache bug that could leave `assigned_dcns: []` forever across DCN
+  restarts.
+- UBLDC dependency bumped: `>=2.11.0` → `>=2.13.0` in `setup.py`,
+  `requirements.txt` and `pyproject.toml` (requires
+  `BinanceLocalDepthCacheManager.set_credentials()`).
 
 ## 0.4.0
 ### Added

--- a/packages/ubdcc-mgmt/CHANGELOG.md
+++ b/packages/ubdcc-mgmt/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this package will be documented in this file.
 ## 0.6.0.dev (development stage/unreleased/unstable)
 
 ## 0.6.0
+### Fixed
+- `/ubdcc_update_depthcache_distribution` read `last_restart_time`
+  from the query string but never forwarded it to
+  `Database.update_depthcache_distribution()`, so the `RESTARTS`
+  counter per distribution entry stayed at `0` forever regardless
+  of how many stream restarts the DCNs reported. The handler also
+  did not cast the query value from `str` to `float`, which would
+  have caused a silent string-vs-float comparison in the DB layer.
+  Both fixed: value is cast (with error response `#1024` on
+  malformed input) and passed through to the DB call.
 
 ## 0.5.0
 

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -5,8 +5,22 @@ All notable changes to this package will be documented in this file.
 ## 0.6.0.dev (development stage/unreleased/unstable)
 
 ## 0.6.0
+### Added
+- `Database.rebalance_account_group(account_group)`: redistributes every
+  active DCN uid (`ROLE=ubdcc-dcn`) round-robin across the credentials
+  available for the given account group. Called from
+  `add_credentials()`, `delete_credentials()`, and from `revise()` via
+  the new `rebalance_credential_assignments_if_needed()` whenever the
+  DCN population changes. Replaces the previous lazy "first caller gets
+  assigned on request" semantics that left `assigned_dcns: []` after
+  any transient `None` return.
 
 ## 0.5.0
+### Changed
+- `AccountGroups`: `binance.com-vanilla-options` now resolves to the
+  `binance.com` account group; `binance.com-vanilla-options-testnet`
+  resolves to `binance.com-futures-testnet`. Vanilla-options depth
+  caches share the same credential pool as their underlying exchange.
 
 ## 0.4.0
 ### Changed

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this package will be documented in this file.
 
 ## 0.6.0.dev (development stage/unreleased/unstable)
 
+## 0.6.0
+### Added
+- CLI `status`: new "DC restarts" section lists every depth cache whose
+  WebSocket stream has been restarted at least once, sorted by restart
+  count descending, with a human-readable "last restart" timestamp
+  (e.g. `45s ago`, `2h ago`). Hidden when no DC has restarted.
+- CLI `--help`: the top-level help now lists the `credentials`
+  subcommands (`add`, `remove`, `list`) in the epilog alongside the
+  interactive shell commands, so users no longer need to run
+  `ubdcc credentials --help` to discover them.
+
+## 0.5.0
+### Added
+- CLI `status`: UBLDC version shown in parentheses next to each DCN's
+  version.
+- CLI `status`: DepthCache redundancy summary — replica breakdown
+  (running/starting) and redundancy categories (fully redundant,
+  degraded, no redundancy).
+
 ## 0.4.0
 ### Removed
 - External `ubdcc restart <name>` CLI subcommand — only worked inside the interactive shell. The shell command is unchanged.


### PR DESCRIPTION
## Summary
Backfills per-package CHANGELOG entries so they match the root CHANGELOG ahead of the 0.6.0 release. Maps each root-level change to the package whose source it touched.

- \`packages/ubdcc/CHANGELOG.md\`: CLI-only changes — 0.6.0 (DC restarts section, credentials subcommands in \`--help\` epilog) + 0.5.0 (UBLDC version in status table, redundancy summary).
- \`packages/ubdcc-dcn/CHANGELOG.md\`: 0.6.0 — credential handling moved from DCN to UBLDC via \`set_credentials()\` hot-swap; UBLDC dep bumped to \`>=2.13.0\`.
- \`packages/ubdcc-mgmt/CHANGELOG.md\`: 0.6.0 — \`/ubdcc_update_depthcache_distribution\` now forwards \`last_restart_time\` to the DB call (restart counter fix).
- \`packages/ubdcc-shared-modules/CHANGELOG.md\`: 0.6.0 — \`Database.rebalance_account_group()\`; 0.5.0 — AccountGroups vanilla-options mapping.
- \`packages/ubdcc-restapi/CHANGELOG.md\`: untouched — no source changes for 0.5.0 or 0.6.0, left the placeholder blocks as-is.

## Test plan
- [x] Cross-checked each entry against actual source diffs from the relevant PRs (#124 / #125 / #126 plus the 0.5.0 release content)
- [x] No claims about behaviour that isn't in the source — rebalance text references the actual new methods, credential-handling text references the actual flow