### PR TITLE
feat(cli): split status redundancy summary into clearer categories

### DIFF
--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.6.0.dev (development stage/unreleased/unstable)
+### Changed
+- CLI `status`: redundancy summary split into clearer categories.
+  Previously a DepthCache with `desired=1, running=0` was reported as
+  "no redundancy" and `desired>=2, running=0` as "degraded", hiding the
+  fact that the cache was completely down. Now:
+  - `unavailable` — desired > 0 but nothing running
+  - `no redundancy` — desired = 1, running = 1
+  - `degraded` — desired >= 2, 0 < running < desired
+  - `fully redundant` — desired >= 2, running >= desired
+  - `inactive` — desired = 0 (only shown when non-zero)
 
 ## 0.6.0
 ### Added

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -490,6 +490,8 @@ def print_status_table(data, mgmt_port=42080):
     fully_redundant = 0
     degraded = 0
     no_redundancy = 0
+    unavailable = 0
+    inactive = 0
     for markets in depthcaches.values():
         for dc in markets.values():
             dc_count += 1
@@ -500,7 +502,11 @@ def print_status_table(data, mgmt_port=42080):
             total_replicas += len(distribution)
             replicas_running += running
             replicas_starting += starting
-            if desired < 2:
+            if desired == 0:
+                inactive += 1
+            elif running == 0:
+                unavailable += 1
+            elif desired == 1:
                 no_redundancy += 1
             elif running >= desired:
                 fully_redundant += 1
@@ -508,7 +514,15 @@ def print_status_table(data, mgmt_port=42080):
                 degraded += 1
 
     print(f"\nDepthCaches: {dc_count} ({total_replicas} replicas: {replicas_running} running, {replicas_starting} starting)")
-    print(f"Redundancy: {fully_redundant} fully redundant, {degraded} degraded, {no_redundancy} no redundancy")
+    parts = [
+        f"{fully_redundant} fully redundant",
+        f"{degraded} degraded",
+        f"{no_redundancy} no redundancy",
+        f"{unavailable} unavailable",
+    ]
+    if inactive:
+        parts.append(f"{inactive} inactive")
+    print(f"Redundancy: {', '.join(parts)}")
     print(f"Version: {data.get('version', '?')}")
 
     dc_restarts = []


### PR DESCRIPTION
## Summary

`ubdcc status` hatte ein Klassifikationsproblem: DepthCaches, die komplett down waren, wurden je nach `DESIRED_QUANTITY` entweder in `no redundancy` (desired=1) oder `degraded` (desired>=2) versteckt — beide Kategorien klingen nach "läuft ja noch was".

Neue Einstufung macht den Ausfall sichtbar:

| desired | running | Kategorie |
|---------|---------|-----------|
| 0       | 0       | inactive (nur sichtbar bei >0) |
| >0      | 0       | **unavailable** |
| 1       | 1       | no redundancy |
| >=2     | 0 < r < desired | degraded |
| >=2     | >= desired | fully redundant |

Beispiel-Output:

```
Redundancy: 1 fully redundant, 1 degraded, 1 no redundancy, 2 unavailable, 1 inactive
```

`inactive` wird nur angehängt, wenn der Zähler > 0 ist, damit die Zeile im Normalfall nicht aufgeblasen wird.

## Test plan

- [x] Syntax-Check von `cli.py`
- [x] Unit-Test der Klassifikationslogik über alle relevanten (desired, running)-Kombinationen (0-5 / 0-5)
- [x] Integrationstest von `print_status_table()` mit gemocktem mgmt-Endpoint, gemischter DepthCache-Verteilung → Zählung stimmt exakt
- [x] Integrationstest: `inactive` wird korrekt weggelassen, wenn Count == 0
- [ ] Live-Test im echten Cluster via `ubdcc status`