### PR TITLE
README: mention the UBDCC Dashboard as a monitoring option

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,10 +608,25 @@ for a native experience with sync and async support, automatic connection handli
 
 See the [examples](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache/tree/master/examples/unicorn_binance_depth_cache_cluster).
 
+## Monitoring with the UBDCC Dashboard
+
+For a browser-based live view of every depth cache in the cluster — compact mini-orderbook tiles, desync and error 
+highlighting, add and remove caches on the fly — use the [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard):
+
+```sh
+pip install ubdcc-dashboard
+ubdcc-dashboard start
+```
+
+Binds to `127.0.0.1:8080` by default and opens the UI in your browser; enter the REST API URL of your cluster 
+(typical: `http://<cluster-host>:42081`) and click `Connect`. See the 
+[dashboard README](https://github.com/oliver-zehentleitner/ubdcc-dashboard#readme) for CLI flags and network exposure.
+
 ## Documentation
 - [General](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster)
 - [Modules](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/modules.html)
 - [ubdcc CLI reference](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/ubdcc.html)
+- [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)
 
 ## Related Articles
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)


### PR DESCRIPTION
## Summary

Points UBDCC users at the companion [ubdcc-dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) project.

- New short section `## Monitoring with the UBDCC Dashboard` between `Accessing from Python` and `Documentation`: install command, default bind, how to connect. Links to the dashboard README for CLI flags and network exposure.
- New link in the `## Documentation` list.

Dashboard remains a separate optional install (not a dependency of this cluster).

## Test plan

- [ ] New section renders between Accessing-from-Python and Documentation
- [ ] `pip install ubdcc-dashboard` instruction copies cleanly
- [ ] Documentation list shows the dashboard link