### PR TITLE
docs(llms.txt): mention UBDCC Dashboard in Related Modules

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -93,6 +93,7 @@ Runs as processes on a single machine or as pods on Kubernetes.
 - [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) — the Python client library for UBDCC; the engine that runs on each DCN.
 - [UBWA](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) — WebSocket streams used by UBLDC under the hood.
 - [UBRA](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) — REST API client used for depth snapshots.
+- [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) — optional browser UI for live monitoring of a running UBDCC cluster (`pip install ubdcc-dashboard` → `ubdcc-dashboard start`).
 
 ## Docs
 

--- a/llms.txt
+++ b/llms.txt
@@ -93,7 +93,7 @@ Runs as processes on a single machine or as pods on Kubernetes.
 - [UBLDC](https://github.com/oliver-zehentleitner/unicorn-binance-local-depth-cache) — the Python client library for UBDCC; the engine that runs on each DCN.
 - [UBWA](https://github.com/oliver-zehentleitner/unicorn-binance-websocket-api) — WebSocket streams used by UBLDC under the hood.
 - [UBRA](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) — REST API client used for depth snapshots.
-- [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) — optional browser UI for live monitoring of a running UBDCC cluster (`pip install ubdcc-dashboard` → `ubdcc-dashboard start`).
+- [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) — optional browser UI for live monitoring and management of a running UBDCC cluster: view status, spot desync, add/remove caches on the fly (`pip install ubdcc-dashboard` → `ubdcc-dashboard start`).
 
 ## Docs
 


### PR DESCRIPTION
## Summary
- `Related Modules` in `llms.txt` listed UBLDC, UBWA, UBRA but not the UBDCC Dashboard
- Agents reading this file had no signal that a browser UI for live cluster monitoring exists
- Added the Dashboard as an optional related client, matching the framing already used in the UBS suite llms.txt

## Test plan
- [ ] Read `llms.txt` — UBDCC Dashboard appears under Related Modules with install/CLI hint