### PR TITLE
fix: map margin-testnet and isolated_margin-testnet to binance.com-testnet account group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.6.0.dev (development stage/unreleased/unstable)
+## 0.6.1.dev (development stage/unreleased/unstable)
+### Fixed
+- `AccountGroups.py`: `binance.com-margin-testnet` and
+  `binance.com-isolated_margin-testnet` are now mapped to the
+  `binance.com-testnet` account group. Without this, credential
+  assignment (`get_account_group()`) returned `None` for testnet-margin
+  DCNs, so no API keys could be dispatched to them. Spot-testnet and
+  margin-testnet share the same `testnet.binance.vision` credentials,
+  so they belong in the same account group.
 
 ## 0.6.0
 ### Added

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -9,7 +9,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.6.0.dev (development stage/unreleased/unstable)
+## 0.6.1.dev (development stage/unreleased/unstable)
+### Fixed
+- `AccountGroups.py`: `binance.com-margin-testnet` and
+  `binance.com-isolated_margin-testnet` are now mapped to the
+  `binance.com-testnet` account group. Without this, credential
+  assignment (`get_account_group()`) returned `None` for testnet-margin
+  DCNs, so no API keys could be dispatched to them. Spot-testnet and
+  margin-testnet share the same `testnet.binance.vision` credentials,
+  so they belong in the same account group.
 
 ## 0.6.0
 ### Added

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/AccountGroups.py
@@ -27,6 +27,8 @@ EXCHANGE_TO_ACCOUNT_GROUP = {
     "binance.com-isolated_margin": "binance.com",
     "binance.com-vanilla-options": "binance.com",
     "binance.com-testnet": "binance.com-testnet",
+    "binance.com-margin-testnet": "binance.com-testnet",
+    "binance.com-isolated_margin-testnet": "binance.com-testnet",
     "binance.com-futures-testnet": "binance.com-futures-testnet",
     "binance.com-vanilla-options-testnet": "binance.com-futures-testnet",
     "binance.us": "binance.us",


### PR DESCRIPTION
## Summary

`EXCHANGE_TO_ACCOUNT_GROUP` in `ubdcc-shared-modules/AccountGroups.py` covered margin/isolated_margin on **mainnet** but was missing the two **testnet** counterparts:

| Exchange | Before | After |
|---|---|---|
| `binance.com-margin-testnet` | *unmapped* → `get_account_group()` returns `None` | `binance.com-testnet` |
| `binance.com-isolated_margin-testnet` | *unmapped* → `get_account_group()` returns `None` | `binance.com-testnet` |

Without the mapping, mgmt-side credential assignment skips DCNs running on those exchanges — no public keys are dispatched to them.

## Why `binance.com-testnet`

Spot-testnet and margin-testnet (cross + isolated) share the same `testnet.binance.vision` account. They log in with the same API key and therefore belong in one account group. UBRA already routes all three variants to `https://testnet.binance.vision/api` for REST.

## Context

Complements the UBLDC margin REST-snapshot fix (oliver-zehentleitner/unicorn-binance-local-depth-cache#105) which enables margin DepthCaches to actually synchronise. With both PRs merged, margin and isolated_margin work end-to-end on mainnet and testnet.

## Test plan

- [ ] `get_account_group("binance.com-margin-testnet")` returns `"binance.com-testnet"`
- [ ] `get_account_group("binance.com-isolated_margin-testnet")` returns `"binance.com-testnet"`
- [ ] A DCN started against `binance.com-margin-testnet` receives credentials dispatched from the `binance.com-testnet` account group
- [ ] Mainnet mappings unchanged (regression check)