### PR TITLE
docs: list margin and isolated_margin (mainnet + testnet) in supported-exchanges and account-group tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ the internet typically ~60ms.
 |--------------------------------------------------------------------|-------------------------------| 
 | [Binance](https://www.binance.com)                                 | `binance.com`                 |
 | [Binance Testnet](https://testnet.binance.vision/)                 | `binance.com-testnet`         |
+| [Binance Cross Margin](https://www.binance.com)                    | `binance.com-margin`          |
+| [Binance Cross Margin Testnet](https://testnet.binance.vision/)    | `binance.com-margin-testnet`  |
+| [Binance Isolated Margin](https://www.binance.com)                 | `binance.com-isolated_margin` |
+| [Binance Isolated Margin Testnet](https://testnet.binance.vision/) | `binance.com-isolated_margin-testnet` |
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
 | [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |
@@ -523,7 +527,7 @@ Each Binance account has its own keys. UBDCC groups related exchanges under one 
 | account_group                   | Covers UBLDC exchanges                                                                                       |
 |---------------------------------|--------------------------------------------------------------------------------------------------------------|
 | `binance.com`                   | `binance.com`, `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`, `binance.com-vanilla-options` |
-| `binance.com-testnet`           | `binance.com-testnet` (Spot testnet — separate login on testnet.binance.vision)                              |
+| `binance.com-testnet`           | `binance.com-testnet`, `binance.com-margin-testnet`, `binance.com-isolated_margin-testnet` (Spot testnet — separate login on testnet.binance.vision; margin testnet shares the same account) |
 | `binance.com-futures-testnet`   | `binance.com-futures-testnet`, `binance.com-vanilla-options-testnet` (shared Futures/Options testnet)        |
 | `binance.us`                    | `binance.us`                                                                                                 |
 | `binance.tr`                    | `trbinance.com`                                                                                              |

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -184,6 +184,10 @@ the internet typically ~60ms.
 |--------------------------------------------------------------------|-------------------------------| 
 | [Binance](https://www.binance.com)                                 | `binance.com`                 |
 | [Binance Testnet](https://testnet.binance.vision/)                 | `binance.com-testnet`         |
+| [Binance Cross Margin](https://www.binance.com)                    | `binance.com-margin`          |
+| [Binance Cross Margin Testnet](https://testnet.binance.vision/)    | `binance.com-margin-testnet`  |
+| [Binance Isolated Margin](https://www.binance.com)                 | `binance.com-isolated_margin` |
+| [Binance Isolated Margin Testnet](https://testnet.binance.vision/) | `binance.com-isolated_margin-testnet` |
 | [Binance USD-M Futures](https://www.binance.com)                   | `binance.com-futures`         |
 | [Binance USD-M Futures Testnet](https://testnet.binancefuture.com) | `binance.com-futures-testnet` |
 | [Binance European Options](https://www.binance.com)                | `binance.com-vanilla-options`         |
@@ -523,7 +527,7 @@ Each Binance account has its own keys. UBDCC groups related exchanges under one 
 | account_group                   | Covers UBLDC exchanges                                                                                       |
 |---------------------------------|--------------------------------------------------------------------------------------------------------------|
 | `binance.com`                   | `binance.com`, `binance.com-futures`, `binance.com-margin`, `binance.com-isolated_margin`, `binance.com-vanilla-options` |
-| `binance.com-testnet`           | `binance.com-testnet` (Spot testnet — separate login on testnet.binance.vision)                              |
+| `binance.com-testnet`           | `binance.com-testnet`, `binance.com-margin-testnet`, `binance.com-isolated_margin-testnet` (Spot testnet — separate login on testnet.binance.vision; margin testnet shares the same account) |
 | `binance.com-futures-testnet`   | `binance.com-futures-testnet`, `binance.com-vanilla-options-testnet` (shared Futures/Options testnet)        |
 | `binance.us`                    | `binance.us`                                                                                                 |
 | `binance.tr`                    | `trbinance.com`                                                                                              |


### PR DESCRIPTION
## Summary

README follow-up that documents the four Binance margin variants across the two exchange-related tables.

## Changes

- **Supported exchanges table**: four new rows — Cross Margin / Isolated Margin × mainnet / testnet, all pointing to the matching `binance.com-*` UBLDC exchange string.
- **Account groups table**: `binance.com-testnet` row extended with `binance.com-margin-testnet` and `binance.com-isolated_margin-testnet` (they share the testnet.binance.vision credentials). Mainnet margin variants were already listed under `binance.com` — no change there.
- `dev/sphinx/source/readme.md`: mirrored.

## Context

Depends on:
- oliver-zehentleitner/unicorn-binance-local-depth-cache#105 (merged) — UBLDC runtime support for all four margin exchanges
- #136 (open) — mgmt-side mapping of margin-testnet + isolated_margin-testnet to the `binance.com-testnet` account group

Mainnet margin works end-to-end once #105 propagates to the pinned UBLDC release. Testnet margin needs #136 to also land for DCN credential assignment to work.