### PR TITLE
refactor(rest): drop ubdcc_ prefix from public credential endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   `cluster.remove_credentials()` / `cluster.get_credentials_list()`.
   The `ubdcc credentials add/list/remove` CLI continues to work unchanged
   (it now hits the new endpoints internally).
+- `packages/ubdcc-dcn`: bumped `unicorn-binance-local-depth-cache`
+  minimum to `>=2.14.0` across `setup.py`, `requirements.txt` and
+  `pyproject.toml` — the renamed cluster client methods live there.
 ### Fixed
 - `AccountGroups.py`: `binance.com-margin-testnet` and
   `binance.com-isolated_margin-testnet` are now mapped to the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.6.1.dev (development stage/unreleased/unstable)
+## 0.7.0.dev (development stage/unreleased/unstable)
+### Changed
+- **Breaking**: dropped the redundant `ubdcc_` prefix from the three
+  user-facing credential endpoints to align with the rest of the REST
+  API (`/create_depthcache`, `/get_asks`, ...):
+  - `/ubdcc_add_credentials` → `/add_credentials`
+  - `/ubdcc_remove_credentials` → `/remove_credentials`
+  - `/ubdcc_get_credentials_list` → `/get_credentials_list`
+  Renamed on both the public restapi and the internal mgmt service.
+  Internal cluster endpoints (`/ubdcc_assign_credentials`,
+  `/ubdcc_node_*`, `/ubdcc_update_depthcache_distribution`, ...) keep
+  their prefix — it signals "not a public API".
+  The matching UBLDC cluster client methods were renamed too (requires
+  UBLDC ≥ 2.14.0): use `cluster.add_credentials()` /
+  `cluster.remove_credentials()` / `cluster.get_credentials_list()`.
+  The `ubdcc credentials add/list/remove` CLI continues to work unchanged
+  (it now hits the new endpoints internally).
 ### Fixed
 - `AccountGroups.py`: `binance.com-margin-testnet` and
   `binance.com-isolated_margin-testnet` are now mapped to the

--- a/README.md
+++ b/README.md
@@ -348,9 +348,9 @@ These are the endpoints you use to interact with the cluster. All requests go th
 | `/get_depthcache_list` | GET | — | List all DepthCaches with status and distribution                                                                                                 |
 | `/get_depthcache_info` | GET | `exchange`, `market` | Detailed info for a specific DepthCache                                                                                                           |
 | `/stop_depthcache` | GET | `exchange`, `market` | Stop and remove a DepthCache                                                                                                                      |
-| `/ubdcc_add_credentials` | POST/GET | `account_group`, `api_key`, `api_secret` | Store a Binance [API key](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret) (see [API Credentials](#api-credentials)) |
-| `/ubdcc_remove_credentials` | POST/GET | `id` | Delete a stored API key                                                                                                                           |
-| `/ubdcc_get_credentials_list` | GET | — | List stored keys (masked) with their assigned DCNs                                                                                                |
+| `/add_credentials` | POST/GET | `account_group`, `api_key`, `api_secret` | Store a Binance [API key](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret) (see [API Credentials](#api-credentials)) |
+| `/remove_credentials` | POST/GET | `id` | Delete a stored API key                                                                                                                           |
+| `/get_credentials_list` | GET | — | List stored keys (masked) with their assigned DCNs                                                                                                |
 
 All public endpoints accept `debug=true` as an additional parameter for timing and routing details.
 
@@ -551,7 +551,7 @@ ubdcc credentials remove <id>
 Or over HTTP:
 
 ```bash
-curl -X POST 'http://127.0.0.1:42081/ubdcc_add_credentials' \
+curl -X POST 'http://127.0.0.1:42081/add_credentials' \
   -H 'Content-Type: application/json' \
   -d '{"account_group":"binance.com","api_key":"...","api_secret":"..."}'
 ```
@@ -565,7 +565,7 @@ assignment. `get_cluster_info` / `credentials list` show which DCNs each key is 
 - **Keys are stored in the cluster DB** (the same DB that is replicated to every pod for
   self-healing). Inside the cluster they are full, cleartext — this is a deliberate trade-off so
   that the self-healing/backup flow keeps working.
-- Public responses (`get_cluster_info`, `ubdcc_get_credentials_list`) only return **masked
+- Public responses (`get_cluster_info`, `get_credentials_list`) only return **masked
   previews** of the key and never the secret. Only the internal `/ubdcc_assign_credentials`
   endpoint returns the full pair, and only to a requesting DCN.
 - It is **your responsibility** to protect the cluster: lock down the network (firewall, private

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -26,6 +26,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   `cluster.remove_credentials()` / `cluster.get_credentials_list()`.
   The `ubdcc credentials add/list/remove` CLI continues to work unchanged
   (it now hits the new endpoints internally).
+- `packages/ubdcc-dcn`: bumped `unicorn-binance-local-depth-cache`
+  minimum to `>=2.14.0` across `setup.py`, `requirements.txt` and
+  `pyproject.toml` — the renamed cluster client methods live there.
 ### Fixed
 - `AccountGroups.py`: `binance.com-margin-testnet` and
   `binance.com-isolated_margin-testnet` are now mapped to the

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -9,7 +9,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.6.1.dev (development stage/unreleased/unstable)
+## 0.7.0.dev (development stage/unreleased/unstable)
+### Changed
+- **Breaking**: dropped the redundant `ubdcc_` prefix from the three
+  user-facing credential endpoints to align with the rest of the REST
+  API (`/create_depthcache`, `/get_asks`, ...):
+  - `/ubdcc_add_credentials` → `/add_credentials`
+  - `/ubdcc_remove_credentials` → `/remove_credentials`
+  - `/ubdcc_get_credentials_list` → `/get_credentials_list`
+  Renamed on both the public restapi and the internal mgmt service.
+  Internal cluster endpoints (`/ubdcc_assign_credentials`,
+  `/ubdcc_node_*`, `/ubdcc_update_depthcache_distribution`, ...) keep
+  their prefix — it signals "not a public API".
+  The matching UBLDC cluster client methods were renamed too (requires
+  UBLDC ≥ 2.14.0): use `cluster.add_credentials()` /
+  `cluster.remove_credentials()` / `cluster.get_credentials_list()`.
+  The `ubdcc credentials add/list/remove` CLI continues to work unchanged
+  (it now hits the new endpoints internally).
 ### Fixed
 - `AccountGroups.py`: `binance.com-margin-testnet` and
   `binance.com-isolated_margin-testnet` are now mapped to the

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -348,9 +348,9 @@ These are the endpoints you use to interact with the cluster. All requests go th
 | `/get_depthcache_list` | GET | — | List all DepthCaches with status and distribution                                                                                                 |
 | `/get_depthcache_info` | GET | `exchange`, `market` | Detailed info for a specific DepthCache                                                                                                           |
 | `/stop_depthcache` | GET | `exchange`, `market` | Stop and remove a DepthCache                                                                                                                      |
-| `/ubdcc_add_credentials` | POST/GET | `account_group`, `api_key`, `api_secret` | Store a Binance [API key](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret) (see [API Credentials](#api-credentials)) |
-| `/ubdcc_remove_credentials` | POST/GET | `id` | Delete a stored API key                                                                                                                           |
-| `/ubdcc_get_credentials_list` | GET | — | List stored keys (masked) with their assigned DCNs                                                                                                |
+| `/add_credentials` | POST/GET | `account_group`, `api_key`, `api_secret` | Store a Binance [API key](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret) (see [API Credentials](#api-credentials)) |
+| `/remove_credentials` | POST/GET | `id` | Delete a stored API key                                                                                                                           |
+| `/get_credentials_list` | GET | — | List stored keys (masked) with their assigned DCNs                                                                                                |
 
 All public endpoints accept `debug=true` as an additional parameter for timing and routing details.
 
@@ -551,7 +551,7 @@ ubdcc credentials remove <id>
 Or over HTTP:
 
 ```bash
-curl -X POST 'http://127.0.0.1:42081/ubdcc_add_credentials' \
+curl -X POST 'http://127.0.0.1:42081/add_credentials' \
   -H 'Content-Type: application/json' \
   -d '{"account_group":"binance.com","api_key":"...","api_secret":"..."}'
 ```
@@ -565,7 +565,7 @@ assignment. `get_cluster_info` / `credentials list` show which DCNs each key is 
 - **Keys are stored in the cluster DB** (the same DB that is replicated to every pod for
   self-healing). Inside the cluster they are full, cleartext — this is a deliberate trade-off so
   that the self-healing/backup flow keeps working.
-- Public responses (`get_cluster_info`, `ubdcc_get_credentials_list`) only return **masked
+- Public responses (`get_cluster_info`, `get_credentials_list`) only return **masked
   previews** of the key and never the secret. Only the internal `/ubdcc_assign_credentials`
   endpoint returns the full pair, and only to a requesting DCN.
 - It is **your responsibility** to protect the cluster: lock down the network (firewall, private

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -22,7 +22,7 @@ repository = "https://github.com/oliver-zehentleitner/unicorn-binance-depth-cach
 [tool.poetry.dependencies]
 python = ">=3.9.0"
 ubdcc-shared-modules = "==0.6.0"
-unicorn_binance_local_depth_cache = ">=2.13.0"
+unicorn_binance_local_depth_cache = ">=2.14.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/packages/ubdcc-dcn/requirements.txt
+++ b/packages/ubdcc-dcn/requirements.txt
@@ -1,2 +1,2 @@
 ubdcc-shared-modules==0.6.0
-unicorn-binance-local-depth-cache>=2.13.0
+unicorn-binance-local-depth-cache>=2.14.0

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -39,7 +39,7 @@ setup(
     long_description_content_type="text/markdown",
     license='MIT',
     install_requires=['ubdcc-shared-modules==0.6.0',
-                      'unicorn-binance-local-depth-cache>=2.13.0'],
+                      'unicorn-binance-local-depth-cache>=2.14.0'],
     keywords='',
     project_urls={
         'Howto': 'https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster#howto',

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py
@@ -79,25 +79,25 @@ class RestEndpoints(RestEndpointsBase):
         async def ubdcc_update_depthcache_distribution(request: Request):
             return await self.ubdcc_update_depthcache_distribution(request=request)
 
-        @self.fastapi.post("/ubdcc_add_credentials")
-        async def ubdcc_add_credentials_post(request: Request):
-            return await self.ubdcc_add_credentials(request=request)
+        @self.fastapi.post("/add_credentials")
+        async def add_credentials_post(request: Request):
+            return await self.add_credentials(request=request)
 
-        @self.fastapi.get("/ubdcc_add_credentials")
-        async def ubdcc_add_credentials_get(request: Request):
-            return await self.ubdcc_add_credentials(request=request)
+        @self.fastapi.get("/add_credentials")
+        async def add_credentials_get(request: Request):
+            return await self.add_credentials(request=request)
 
-        @self.fastapi.post("/ubdcc_remove_credentials")
-        async def ubdcc_remove_credentials_post(request: Request):
-            return await self.ubdcc_remove_credentials(request=request)
+        @self.fastapi.post("/remove_credentials")
+        async def remove_credentials_post(request: Request):
+            return await self.remove_credentials(request=request)
 
-        @self.fastapi.get("/ubdcc_remove_credentials")
-        async def ubdcc_remove_credentials_get(request: Request):
-            return await self.ubdcc_remove_credentials(request=request)
+        @self.fastapi.get("/remove_credentials")
+        async def remove_credentials_get(request: Request):
+            return await self.remove_credentials(request=request)
 
-        @self.fastapi.get("/ubdcc_get_credentials_list")
-        async def ubdcc_get_credentials_list(request: Request):
-            return await self.ubdcc_get_credentials_list(request=request)
+        @self.fastapi.get("/get_credentials_list")
+        async def get_credentials_list(request: Request):
+            return await self.get_credentials_list(request=request)
 
         @self.fastapi.get("/ubdcc_assign_credentials")
         async def ubdcc_assign_credentials(request: Request):
@@ -420,8 +420,8 @@ class RestEndpoints(RestEndpointsBase):
             return self.get_error_response(event=event, error_id="#1010",
                                            message="An unknown error has occurred!")
 
-    async def ubdcc_add_credentials(self, request: Request):
-        event = "UBDCC_ADD_CREDENTIALS"
+    async def add_credentials(self, request: Request):
+        event = "ADD_CREDENTIALS"
         ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
         if ready_check is not None:
             return ready_check
@@ -453,8 +453,8 @@ class RestEndpoints(RestEndpointsBase):
             return self.get_error_response(event=event, error_id="#1032", message=str(error_msg))
         return self.get_ok_response(event=event, params={"id": credential_id})
 
-    async def ubdcc_remove_credentials(self, request: Request):
-        event = "UBDCC_REMOVE_CREDENTIALS"
+    async def remove_credentials(self, request: Request):
+        event = "REMOVE_CREDENTIALS"
         ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
         if ready_check is not None:
             return ready_check
@@ -476,8 +476,8 @@ class RestEndpoints(RestEndpointsBase):
         return self.get_error_response(event=event, error_id="#1034",
                                        message=f"Credentials '{credential_id}' not found!")
 
-    async def ubdcc_get_credentials_list(self, request: Request):
-        event = "UBDCC_GET_CREDENTIALS_LIST"
+    async def get_credentials_list(self, request: Request):
+        event = "GET_CREDENTIALS_LIST"
         ready_check = self.throw_error_if_mgmt_not_ready(request=request, event=event)
         if ready_check is not None:
             return ready_check

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py
@@ -64,25 +64,25 @@ class RestEndpoints(RestEndpointsBase):
         async def stop_depthcache(request: Request):
             return await self.stop_depthcache(request=request)
 
-        @self.fastapi.post("/ubdcc_add_credentials")
-        async def ubdcc_add_credentials_post(request: Request):
-            return await self.ubdcc_add_credentials(request=request)
+        @self.fastapi.post("/add_credentials")
+        async def add_credentials_post(request: Request):
+            return await self.add_credentials(request=request)
 
-        @self.fastapi.get("/ubdcc_add_credentials")
-        async def ubdcc_add_credentials_get(request: Request):
-            return await self.ubdcc_add_credentials(request=request)
+        @self.fastapi.get("/add_credentials")
+        async def add_credentials_get(request: Request):
+            return await self.add_credentials(request=request)
 
-        @self.fastapi.post("/ubdcc_remove_credentials")
-        async def ubdcc_remove_credentials_post(request: Request):
-            return await self.ubdcc_remove_credentials(request=request)
+        @self.fastapi.post("/remove_credentials")
+        async def remove_credentials_post(request: Request):
+            return await self.remove_credentials(request=request)
 
-        @self.fastapi.get("/ubdcc_remove_credentials")
-        async def ubdcc_remove_credentials_get(request: Request):
-            return await self.ubdcc_remove_credentials(request=request)
+        @self.fastapi.get("/remove_credentials")
+        async def remove_credentials_get(request: Request):
+            return await self.remove_credentials(request=request)
 
-        @self.fastapi.get("/ubdcc_get_credentials_list")
-        async def ubdcc_get_credentials_list(request: Request):
-            return await self.ubdcc_get_credentials_list(request=request)
+        @self.fastapi.get("/get_credentials_list")
+        async def get_credentials_list(request: Request):
+            return await self.get_credentials_list(request=request)
 
     async def _get_depthcache_data(self, request: Request, event=None, endpoint=None):
         process_start_time: float | None = time.time() if str(request.query_params.get("debug")).lower() == "true" \
@@ -358,17 +358,17 @@ class RestEndpoints(RestEndpointsBase):
                                            params={"error": str(result)}, process_start_time=process_start_time,
                                            url=request_url, post_body=post_body, used_pods=used_pods)
 
-    async def ubdcc_add_credentials(self, request: Request):
-        return await self._proxy_to_mgmt(request=request, event="UBDCC_ADD_CREDENTIALS",
-                                         endpoint="/ubdcc_add_credentials", allow_post=True)
+    async def add_credentials(self, request: Request):
+        return await self._proxy_to_mgmt(request=request, event="ADD_CREDENTIALS",
+                                         endpoint="/add_credentials", allow_post=True)
 
-    async def ubdcc_remove_credentials(self, request: Request):
-        return await self._proxy_to_mgmt(request=request, event="UBDCC_REMOVE_CREDENTIALS",
-                                         endpoint="/ubdcc_remove_credentials", allow_post=True)
+    async def remove_credentials(self, request: Request):
+        return await self._proxy_to_mgmt(request=request, event="REMOVE_CREDENTIALS",
+                                         endpoint="/remove_credentials", allow_post=True)
 
-    async def ubdcc_get_credentials_list(self, request: Request):
-        return await self._proxy_to_mgmt(request=request, event="UBDCC_GET_CREDENTIALS_LIST",
-                                         endpoint="/ubdcc_get_credentials_list")
+    async def get_credentials_list(self, request: Request):
+        return await self._proxy_to_mgmt(request=request, event="GET_CREDENTIALS_LIST",
+                                         endpoint="/get_credentials_list")
 
     async def stop_depthcache(self, request: Request):
         process_start_time: float | None = time.time() if str(request.query_params.get("debug")).lower() == "true" else None

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -563,7 +563,7 @@ def cmd_credentials_add(args):
                "api_key": args.api_key,
                "api_secret": args.api_secret}
     try:
-        r = requests.post(f"http://127.0.0.1:{port}/ubdcc_add_credentials", json=payload, timeout=5)
+        r = requests.post(f"http://127.0.0.1:{port}/add_credentials", json=payload, timeout=5)
         data = r.json()
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)
@@ -578,7 +578,7 @@ def cmd_credentials_add(args):
 def cmd_credentials_remove(args):
     port = get_mgmt_port(args)
     try:
-        r = requests.get(f"http://127.0.0.1:{port}/ubdcc_remove_credentials",
+        r = requests.get(f"http://127.0.0.1:{port}/remove_credentials",
                          params={"id": args.id}, timeout=5)
         data = r.json()
     except Exception as e:
@@ -594,7 +594,7 @@ def cmd_credentials_remove(args):
 def cmd_credentials_list(args):
     port = get_mgmt_port(args)
     try:
-        r = requests.get(f"http://127.0.0.1:{port}/ubdcc_get_credentials_list", timeout=5)
+        r = requests.get(f"http://127.0.0.1:{port}/get_credentials_list", timeout=5)
         data = r.json()
     except Exception as e:
         print(f"Error: {e}", file=sys.stderr)


### PR DESCRIPTION
## Summary

The three user-facing credential endpoints were the only entries in the public REST API still carrying a `ubdcc_` prefix. Everything else (`create_depthcache`, `get_asks`, `stop_depthcache`, `get_cluster_info`, ...) lives without it. Cleanup for consistency.

## Rename

| Before | After |
|---|---|
| `POST/GET /ubdcc_add_credentials` | `POST/GET /add_credentials` |
| `POST/GET /ubdcc_remove_credentials` | `POST/GET /remove_credentials` |
| `GET /ubdcc_get_credentials_list` | `GET /get_credentials_list` |

Internal cluster endpoints (`/ubdcc_assign_credentials`, `/ubdcc_node_*`, `/ubdcc_update_depthcache_distribution`, `/ubdcc_mgmt_backup`, ...) **keep the prefix** — it signals "not a public API". Different audience, different concern.

## Scope

- `packages/ubdcc-restapi/ubdcc_restapi/RestEndpoints.py` — 6 route decorators, 3 handler methods, 3 proxy-to-mgmt calls
- `packages/ubdcc-mgmt/ubdcc_mgmt/RestEndpoints.py` — 6 route decorators, 3 handler methods, 3 event-name strings
- `packages/ubdcc/ubdcc/cli.py` — 3 URL strings (CLI continues to work transparently)
- README.md + `dev/sphinx/source/readme.md` — REST API table + curl sample in "API Credentials" section
- CHANGELOG.md + mirror — header bumped to `0.7.0.dev`, Changed entry added above the existing Fixed entry

## No deprecation aliases

UBDCC is pre-1.0 and Oliver confirmed the user base is essentially zero. Clean cut is cheaper than carrying compatibility code.

## Coordination

Matching UBLDC cluster client rename in oliver-zehentleitner/unicorn-binance-local-depth-cache#107 — use UBLDC >= 2.14.0 (which also ships with this cluster endpoint change encoded in its client).

## Test plan

- [ ] `curl http://127.0.0.1:42081/add_credentials -X POST -d '{"account_group":"binance.com","api_key":"...","api_secret":"..."}'` returns OK with generated id
- [ ] `curl http://127.0.0.1:42081/get_credentials_list` lists it (masked)
- [ ] `curl http://127.0.0.1:42081/remove_credentials -X POST -d '{"id":"..."}'` deletes it
- [ ] `ubdcc credentials add/list/remove` CLI still works (uses new URLs internally)
- [ ] Old `/ubdcc_*_credentials*` paths return 404 (confirm full removal, no aliases left)
- [ ] DCN credential dispatch continues to work via internal `/ubdcc_assign_credentials` (unchanged)