### PR TITLE
docs(readme): advertise the Dashboard's API Builder as an onboarding helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,23 @@ When running locally (dev mode), the restapi exposes FastAPI's built-in interact
 
 These endpoints are disabled in productive mode (Kubernetes).
 
+### API Builder (dashboard)
+
+For onboarding and day-to-day exploration the
+[UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)
+ships an **API Builder** — pick a task (create a DepthCache, query asks/bids,
+add credentials, stop a cache, …), fill in a form, and copy a ready-to-paste
+REST-API snippet in your language of choice (curl, HTTPie, Python (using the
+official UBLDC `Cluster` client), JavaScript, Go, C#, Java, Rust). A
+`Try it →` button runs GET-safe calls against the connected cluster and
+pretty-prints the response — useful for learning the endpoints without
+writing code first.
+
+```bash
+pip install ubdcc-dashboard
+ubdcc-dashboard start
+```
+
 ### Public Endpoints (restapi)
 
 These are the endpoints you use to interact with the cluster. All requests go through the restapi.

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -334,6 +334,23 @@ When running locally (dev mode), the restapi exposes FastAPI's built-in interact
 
 These endpoints are disabled in productive mode (Kubernetes).
 
+### API Builder (dashboard)
+
+For onboarding and day-to-day exploration the
+[UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)
+ships an **API Builder** — pick a task (create a DepthCache, query asks/bids,
+add credentials, stop a cache, …), fill in a form, and copy a ready-to-paste
+REST-API snippet in your language of choice (curl, HTTPie, Python (using the
+official UBLDC `Cluster` client), JavaScript, Go, C#, Java, Rust). A
+`Try it →` button runs GET-safe calls against the connected cluster and
+pretty-prints the response — useful for learning the endpoints without
+writing code first.
+
+```bash
+pip install ubdcc-dashboard
+ubdcc-dashboard start
+```
+
 ### Public Endpoints (restapi)
 
 These are the endpoints you use to interact with the cluster. All requests go through the restapi.


### PR DESCRIPTION
## Summary

Adds a short section under **REST API → Interactive API docs** that points devs at the [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)'s **API Builder** — a pick-a-task / fill-a-form / copy-a-snippet tool that generates ready-to-paste REST calls in curl, HTTPie, Python (via the official UBLDC `Cluster` client), JavaScript, Go, C#, Java, and Rust, plus a `Try it →` button for GET-safe tasks.

## Why

Swagger / ReDoc cover the reference. The API Builder covers the "I'd like to try this from my language right now" need that Swagger doesn't serve. Having both linked side-by-side in the same section means new users find whichever style fits them without hunting.

## Files

- `README.md` — one new `### API Builder (dashboard)` subsection right after `### Interactive API docs`
- `dev/sphinx/source/readme.md` mirrored