### PR TITLE
deps(ubdcc): bundle ubdcc-dashboard as runtime dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
+
+## 0.7.1
 ### Added
 - `packages/ubdcc`: ships `ubdcc-dashboard >= 0.2.0` as a runtime
   dependency (`setup.py`, `requirements.txt`, `pyproject.toml`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
+### Added
+- `packages/ubdcc`: ships `ubdcc-dashboard >= 0.2.0` as a runtime
+  dependency (`setup.py`, `requirements.txt`, `pyproject.toml`).
+  `pip install ubdcc` now also installs the browser-based UBDCC
+  Dashboard — launch it with `ubdcc-dashboard start`. README updated
+  accordingly.
 
 ## 0.7.0
 ### Changed

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ DepthCache data without duplicate WebSocket connections.
 pip install ubdcc
 ```
 
-This installs all components (mgmt, restapi, dcn) and the `ubdcc` cluster manager.
+This installs all components (mgmt, restapi, dcn), the `ubdcc` cluster manager and the
+[UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) (browser UI,
+launched via `ubdcc-dashboard start`).
 
 ### Start with the cluster manager
 
@@ -341,13 +343,15 @@ For onboarding and day-to-day exploration the
 ships an **API Builder** — pick a task (create a DepthCache, query asks/bids,
 add credentials, stop a cache, …), fill in a form, and copy a ready-to-paste
 REST-API snippet in your language of choice (curl, HTTPie, Python (using the
-official UBLDC `Cluster` client), JavaScript, Go, C#, Java, Rust). A
-`Try it →` button runs GET-safe calls against the connected cluster and
+official UBLDC `Cluster` client), JavaScript, Go, C#, Java, Rust, PHP, C/C++).
+A `Try it →` button runs GET-safe calls against the connected cluster and
 pretty-prints the response — useful for learning the endpoints without
 writing code first.
 
+The dashboard ships as a dependency of `ubdcc` (since 0.7.1) — `pip install ubdcc`
+already pulls it in. Launch it with:
+
 ```bash
-pip install ubdcc-dashboard
 ubdcc-dashboard start
 ```
 

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
+
+## 0.7.1
 ### Added
 - `packages/ubdcc`: ships `ubdcc-dashboard >= 0.2.0` as a runtime
   dependency (`setup.py`, `requirements.txt`, `pyproject.toml`).

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
+### Added
+- `packages/ubdcc`: ships `ubdcc-dashboard >= 0.2.0` as a runtime
+  dependency (`setup.py`, `requirements.txt`, `pyproject.toml`).
+  `pip install ubdcc` now also installs the browser-based UBDCC
+  Dashboard — launch it with `ubdcc-dashboard start`. README updated
+  accordingly.
 
 ## 0.7.0
 ### Changed

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -213,7 +213,9 @@ DepthCache data without duplicate WebSocket connections.
 pip install ubdcc
 ```
 
-This installs all components (mgmt, restapi, dcn) and the `ubdcc` cluster manager.
+This installs all components (mgmt, restapi, dcn), the `ubdcc` cluster manager and the
+[UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) (browser UI,
+launched via `ubdcc-dashboard start`).
 
 ### Start with the cluster manager
 
@@ -341,13 +343,15 @@ For onboarding and day-to-day exploration the
 ships an **API Builder** — pick a task (create a DepthCache, query asks/bids,
 add credentials, stop a cache, …), fill in a form, and copy a ready-to-paste
 REST-API snippet in your language of choice (curl, HTTPie, Python (using the
-official UBLDC `Cluster` client), JavaScript, Go, C#, Java, Rust). A
-`Try it →` button runs GET-safe calls against the connected cluster and
+official UBLDC `Cluster` client), JavaScript, Go, C#, Java, Rust, PHP, C/C++).
+A `Try it →` button runs GET-safe calls against the connected cluster and
 pretty-prints the response — useful for learning the endpoints without
 writing code first.
 
+The dashboard ships as a dependency of `ubdcc` (since 0.7.1) — `pip install ubdcc`
+already pulls it in. Launch it with:
+
 ```bash
-pip install ubdcc-dashboard
 ubdcc-dashboard start
 ```
 

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
+
+## 0.7.1
 ### Added
 - Bundled `ubdcc-dashboard >= 0.2.0` as a runtime dependency. `pip
   install ubdcc` now also installs the browser-based UBDCC Dashboard —

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
+### Added
+- Bundled `ubdcc-dashboard >= 0.2.0` as a runtime dependency. `pip
+  install ubdcc` now also installs the browser-based UBDCC Dashboard —
+  launch it from a separate terminal with `ubdcc-dashboard start`.
 
 ## 0.7.0
 ### Changed

--- a/packages/ubdcc/pyproject.toml
+++ b/packages/ubdcc/pyproject.toml
@@ -24,6 +24,7 @@ python = ">=3.9.0"
 ubdcc-mgmt = "==0.7.0"
 ubdcc-restapi = "==0.7.0"
 ubdcc-dcn = "==0.7.0"
+ubdcc-dashboard = ">=0.2.0"
 
 [tool.poetry.scripts]
 ubdcc = "ubdcc.cli:main"

--- a/packages/ubdcc/requirements.txt
+++ b/packages/ubdcc/requirements.txt
@@ -1,3 +1,4 @@
 ubdcc-mgmt==0.7.0
 ubdcc-restapi==0.7.0
 ubdcc-dcn==0.7.0
+ubdcc-dashboard>=0.2.0

--- a/packages/ubdcc/setup.py
+++ b/packages/ubdcc/setup.py
@@ -38,7 +38,8 @@ setup(
     packages=find_packages(),
     install_requires=['ubdcc-mgmt==0.7.0',
                       'ubdcc-restapi==0.7.0',
-                      'ubdcc-dcn==0.7.0'],
+                      'ubdcc-dcn==0.7.0',
+                      'ubdcc-dashboard>=0.2.0'],
     entry_points={
         "console_scripts": [
             "ubdcc=ubdcc.cli:main",


### PR DESCRIPTION
## Summary

`pip install ubdcc` now also installs `ubdcc-dashboard` so new users get the browser UI out of the box — no separate install step.

## Pin choice

`ubdcc-dashboard >= 0.2.0` (floating, not `==`).

The dashboard ships on its own release cadence outside this monorepo, and it already nags users about outdated installs via the in-app version badge (animated rainbow when PyPI has a newer release). A floating minimum lets `pip install ubdcc` always pull the latest dashboard, while pinning the suite-internal packages exactly as before.

## Files

- `packages/ubdcc/setup.py` — `install_requires` adds `ubdcc-dashboard >= 0.2.0`
- `packages/ubdcc/requirements.txt` — same
- `packages/ubdcc/pyproject.toml` — same
- `README.md`:
  - Local Setup → Install: now mentions the bundled dashboard
  - REST API → API Builder section: drops the separate `pip install ubdcc-dashboard` line, points users at `ubdcc-dashboard start` (since the package is already installed). Also extended the language list with PHP and C/C++ to match dashboard 0.2.1.
- `CHANGELOG.md` + `packages/ubdcc/CHANGELOG.md` — entry under `0.7.1.dev`
- `dev/sphinx/source/{readme,changelog}.md` — mirrored

## Test plan

- [ ] `pip install ubdcc==0.7.1` (after release) pulls `ubdcc-dashboard` automatically
- [ ] `ubdcc-dashboard --version` works post-install
- [ ] `pip install -U ubdcc` upgrades the dashboard along with the suite when a newer dashboard is on PyPI
- [ ] No version conflict resolution errors on the suite-internal `==0.7.0` pins