### PR TITLE
docs(readme): drop "(since 0.7.1)" version-specific note

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ A `Try it →` button runs GET-safe calls against the connected cluster and
 pretty-prints the response — useful for learning the endpoints without
 writing code first.
 
-The dashboard ships as a dependency of `ubdcc` (since 0.7.1) — `pip install ubdcc`
+The dashboard ships as a dependency of `ubdcc` — `pip install ubdcc`
 already pulls it in. Launch it with:
 
 ```bash

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -348,7 +348,7 @@ A `Try it →` button runs GET-safe calls against the connected cluster and
 pretty-prints the response — useful for learning the endpoints without
 writing code first.
 
-The dashboard ships as a dependency of `ubdcc` (since 0.7.1) — `pip install ubdcc`
+The dashboard ships as a dependency of `ubdcc` — `pip install ubdcc`
 already pulls it in. Launch it with:
 
 ```bash


### PR DESCRIPTION
## Summary

Project is still young and just leaving beta — readme should describe
the current state, not historical version hints. Dropped the inline
`(since 0.7.1)` qualifier next to the dashboard-ships-as-dependency
mention in `README.md` and the sphinx mirror.

## Test plan
- [ ] Render `README.md` on GitHub and confirm the API Builder
      (dashboard) section reads cleanly.
- [ ] Build sphinx docs locally and confirm the mirror reflects the
      same change.