### PR TITLE
feat(cli): add --log-level switch and lower default to ERROR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 0.7.1.dev (development stage/unreleased/unstable)
 
 ## 0.7.1
+### Changed
+- **Default service log level lowered from `DEBUG` to `ERROR`** in
+  `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py`. Cuts
+  disk usage in production drastically — `~/.unicorn-binance-suite/logs/ubdcc-*.log`
+  no longer fills up with per-tick DEBUG noise. Affects every service
+  (mgmt, restapi, dcn) regardless of how it's launched (`ubdcc start`,
+  K8s, manual).
 ### Added
 - `packages/ubdcc`: ships `ubdcc-dashboard >= 0.2.0` as a runtime
   dependency (`setup.py`, `requirements.txt`, `pyproject.toml`).
   `pip install ubdcc` now also installs the browser-based UBDCC
   Dashboard — launch it with `ubdcc-dashboard start`. README updated
   accordingly.
+- `ubdcc start --log-level DEBUG|INFO|WARNING|ERROR|CRITICAL` to pick
+  a log level for the spawned mgmt / restapi / dcn services without
+  having to edit code. Propagated as a `log_level` constructor kwarg
+  through `Mgmt`, `RestApi`, `DepthCacheNode` → `ServiceBase` → `App`.
 
 ## 0.7.0
 ### Changed

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -12,12 +12,23 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## 0.7.1.dev (development stage/unreleased/unstable)
 
 ## 0.7.1
+### Changed
+- **Default service log level lowered from `DEBUG` to `ERROR`** in
+  `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py`. Cuts
+  disk usage in production drastically — `~/.unicorn-binance-suite/logs/ubdcc-*.log`
+  no longer fills up with per-tick DEBUG noise. Affects every service
+  (mgmt, restapi, dcn) regardless of how it's launched (`ubdcc start`,
+  K8s, manual).
 ### Added
 - `packages/ubdcc`: ships `ubdcc-dashboard >= 0.2.0` as a runtime
   dependency (`setup.py`, `requirements.txt`, `pyproject.toml`).
   `pip install ubdcc` now also installs the browser-based UBDCC
   Dashboard — launch it with `ubdcc-dashboard start`. README updated
   accordingly.
+- `ubdcc start --log-level DEBUG|INFO|WARNING|ERROR|CRITICAL` to pick
+  a log level for the spawned mgmt / restapi / dcn services without
+  having to edit code. Propagated as a `log_level` constructor kwarg
+  through `Mgmt`, `RestApi`, `DepthCacheNode` → `ServiceBase` → `App`.
 
 ## 0.7.0
 ### Changed

--- a/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
+++ b/packages/ubdcc-dcn/ubdcc_dcn/DepthCacheNode.py
@@ -28,7 +28,7 @@ from unicorn_binance_local_depth_cache.manager import __version__ as ubldc_versi
 
 
 class DepthCacheNode(ServiceBase):
-    def __init__(self, cwd=None, mgmt_port=None):
+    def __init__(self, cwd=None, mgmt_port=None, log_level=None):
         # Thread-safe queue: UBLDC on_restart callbacks fire from their
         # manager thread; the async main loop drains the queue and forwards
         # to mgmt. Must be initialized BEFORE super().__init__() because
@@ -36,7 +36,7 @@ class DepthCacheNode(ServiceBase):
         # synchronously runs main() → _drain_restart_queue(). Any attribute
         # set after super().__init__() is never assigned.
         self._restart_queue: queue.Queue = queue.Queue()
-        super().__init__(app_name="ubdcc-dcn", cwd=cwd, mgmt_port=mgmt_port)
+        super().__init__(app_name="ubdcc-dcn", cwd=cwd, mgmt_port=mgmt_port, log_level=log_level)
 
     def _on_stream_restart(self, exchange: str, market: str, timestamp: float) -> None:
         """Thread-safe: invoked from UBLDC's manager thread on every stream restart."""

--- a/packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
+++ b/packages/ubdcc-mgmt/ubdcc_mgmt/Mgmt.py
@@ -22,8 +22,8 @@ from ubdcc_shared_modules.ServiceBase import ServiceBase
 
 
 class Mgmt(ServiceBase):
-    def __init__(self, cwd=None, mgmt_port=None):
-        super().__init__(app_name="ubdcc-mgmt", cwd=cwd, mgmt_port=mgmt_port)
+    def __init__(self, cwd=None, mgmt_port=None, log_level=None):
+        super().__init__(app_name="ubdcc-mgmt", cwd=cwd, mgmt_port=mgmt_port, log_level=log_level)
 
     async def main(self):
         self.db_init()

--- a/packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
+++ b/packages/ubdcc-restapi/ubdcc_restapi/RestApi.py
@@ -22,8 +22,8 @@ from ubdcc_shared_modules.ServiceBase import ServiceBase
 
 
 class RestApi(ServiceBase):
-    def __init__(self, cwd=None, mgmt_port=None):
-        super().__init__(app_name="ubdcc-restapi", cwd=cwd, mgmt_port=mgmt_port)
+    def __init__(self, cwd=None, mgmt_port=None, log_level=None):
+        super().__init__(app_name="ubdcc-restapi", cwd=cwd, mgmt_port=mgmt_port, log_level=log_level)
 
     async def main(self):
         await self.start_rest_server(endpoints=RestEndpoints)

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this package will be documented in this file.
 
 ## 0.7.1.dev (development stage/unreleased/unstable)
 
+## 0.7.1
+### Changed
+- **`App.py`: default log level is now `ERROR` (was `DEBUG`).** Cuts
+  per-tick disk noise so production deployments don't fill the log
+  directory. Override with the new `log_level` kwarg on `App()` or via
+  `ServiceBase` subclasses (`Mgmt`, `RestApi`, `DepthCacheNode`).
+### Added
+- `App.__init__` and `ServiceBase.__init__` accept a `log_level` kwarg
+  (str: `DEBUG|INFO|WARNING|ERROR|CRITICAL`, or any `logging.*` int).
+  When `None`, falls back to the new `ERROR` default.
+
 ## 0.7.0
 ### Fixed
 - `AccountGroups.py`: added `binance.com-margin-testnet` and

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -47,7 +47,7 @@ VERSION: str = "0.7.0"
 
 class App:
     def __init__(self, app_name=None, cwd=None, mgmt_port=None, logger=None, service=None, service_call=None,
-                 stop_call=None):
+                 stop_call=None, log_level=None):
         self.app_name = app_name
         self.app_version = VERSION
         self.api_port_rest: int = 0
@@ -58,6 +58,7 @@ class App:
         self.info: dict = {}
         self.k8s_client = None
         self.k8s_metrics_client = None
+        self.log_level = log_level
         self.logger = logger
         self.pod_info = None
         self.node_info = None
@@ -355,7 +356,10 @@ class App:
             self.logger = logging.getLogger("unicorn_binance_depthcache_cluster")
             ubs_logs = os.path.join(str(Path.home()), ".unicorn-binance-suite", "logs")
             os.makedirs(ubs_logs, exist_ok=True)
-            logging.basicConfig(level=logging.DEBUG,
+            level = self.log_level if self.log_level is not None else logging.ERROR
+            if isinstance(level, str):
+                level = getattr(logging, level.upper(), logging.ERROR)
+            logging.basicConfig(level=level,
                                 filename=os.path.join(ubs_logs, f"ubdcc-{socket.gethostname()}.log"),
                                 format="{asctime} [{levelname:8}] {process} {thread} {module}: {message}",
                                 style="{")

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/ServiceBase.py
@@ -25,7 +25,7 @@ from .Database import Database
 
 
 class ServiceBase:
-    def __init__(self, app_name=None, cwd=None, mgmt_port=None):
+    def __init__(self, app_name=None, cwd=None, mgmt_port=None, log_level=None):
         self.db: Database | None = None
         self.rest_server = None
         self.app = App(app_name=app_name,
@@ -33,7 +33,8 @@ class ServiceBase:
                        mgmt_port=mgmt_port,
                        service=self,
                        service_call=self.run,
-                       stop_call=self.stop)
+                       stop_call=self.stop,
+                       log_level=log_level)
         self.app.start()
         # Never gets executed ;)
 

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -9,6 +9,10 @@ All notable changes to this package will be documented in this file.
 - Bundled `ubdcc-dashboard >= 0.2.0` as a runtime dependency. `pip
   install ubdcc` now also installs the browser-based UBDCC Dashboard —
   launch it from a separate terminal with `ubdcc-dashboard start`.
+- `ubdcc start --log-level DEBUG|INFO|WARNING|ERROR|CRITICAL` selects
+  the log level for the spawned mgmt / restapi / dcn services. Default
+  is `ERROR` (changed from `DEBUG` in shared-modules) to keep
+  production logs from filling the disk.
 
 ## 0.7.0
 ### Changed

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -108,6 +108,8 @@ def cmd_start(args):
     mgmt_port = args.port if args.port else find_free_port(DEFAULT_MGMT_PORT)
     dcn_count = args.dcn
     logdir = args.logdir if args.logdir else UBS_LOGS
+    log_level = args.log_level
+    log_level_kwarg = f", log_level='{log_level}'" if log_level else ""
     os.makedirs(logdir, exist_ok=True)
     save_port(mgmt_port)
 
@@ -123,7 +125,8 @@ def cmd_start(args):
         log = open(os.path.join(logdir, "ubdcc-mgmt.log"), "a")
         proc = subprocess.Popen(
             [sys.executable, "-c",
-             f"import os; from ubdcc_mgmt.Mgmt import Mgmt; Mgmt(cwd='{cwd}', mgmt_port={mgmt_port})"],
+             f"import os; from ubdcc_mgmt.Mgmt import Mgmt; "
+             f"Mgmt(cwd='{cwd}', mgmt_port={mgmt_port}{log_level_kwarg})"],
             stdout=log, stderr=subprocess.STDOUT
         )
         # Remove old mgmt from processes list
@@ -138,7 +141,8 @@ def cmd_start(args):
         log = open(os.path.join(logdir, "ubdcc-restapi.log"), "a")
         proc = subprocess.Popen(
             [sys.executable, "-c",
-             f"import os; from ubdcc_restapi.RestApi import RestApi; RestApi(cwd='{cwd}', mgmt_port={mgmt_port})"],
+             f"import os; from ubdcc_restapi.RestApi import RestApi; "
+             f"RestApi(cwd='{cwd}', mgmt_port={mgmt_port}{log_level_kwarg})"],
             stdout=log, stderr=subprocess.STDOUT
         )
         # Remove old restapi from processes list
@@ -156,7 +160,7 @@ def cmd_start(args):
         proc = subprocess.Popen(
             [sys.executable, "-c",
              f"import os; from ubdcc_dcn.DepthCacheNode import DepthCacheNode; "
-             f"DepthCacheNode(cwd='{cwd}', mgmt_port={mgmt_port})"],
+             f"DepthCacheNode(cwd='{cwd}', mgmt_port={mgmt_port}{log_level_kwarg})"],
             stdout=log, stderr=subprocess.STDOUT
         )
         processes.append((f"dcn-{nr}", proc, log))
@@ -639,6 +643,9 @@ def build_parser():
     start_parser.add_argument('--dcn', type=int, default=1, help='Number of DCN processes (default: 1)')
     start_parser.add_argument('--port', type=int, default=None, help='Mgmt port (default: 42080 or next free)')
     start_parser.add_argument('--logdir', type=str, default=None, help='Log directory (default: current directory)')
+    start_parser.add_argument('--log-level', type=str, default=None,
+                              choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+                              help='Log level for spawned services (default: ERROR)')
 
     # status
     status_parser = subparsers.add_parser('status', help='Show cluster status')


### PR DESCRIPTION
## Summary

- **Default service log level lowered from `DEBUG` to `ERROR`** in
  `App.py`. Previously every mgmt / restapi / dcn process flooded
  `~/.unicorn-binance-suite/logs/ubdcc-*.log` with per-tick noise —
  fine for development, painful in production where it eats disk.
- **New `--log-level` switch on `ubdcc start`** so verbose output is
  one flag away when investigating an issue:
  ```bash
  ubdcc start --log-level DEBUG
  ubdcc start --log-level INFO --dcn 4
  ```
  Choices: `DEBUG | INFO | WARNING | ERROR | CRITICAL`. Validated by
  argparse `choices=` for an early, clear error.
- Plumbed as a `log_level` constructor kwarg through `Mgmt`,
  `RestApi`, `DepthCacheNode` → `ServiceBase` → `App`, mirroring how
  `cwd` / `mgmt_port` already flow.

## Scope

CLI-only by design — no env var, no K8s / Helm wiring (no existing
env infrastructure to follow, would have been greenfield). The
default-level change still propagates to K8s deployments via `App.py`
and is the production-safe direction.

## Test plan
- [x] `python -c "from ubdcc.cli import build_parser; ..."` — argparse
      accepts valid levels, rejects invalid (`TRACE` → SystemExit).
- [ ] `ubdcc start` (no flag) → cluster comes up, `ubdcc-*.log` only
      shows ERROR-and-above.
- [ ] `ubdcc start --log-level DEBUG` → cluster comes up, `ubdcc-*.log`
      shows the previous DEBUG-level output.
- [ ] `ubdcc start --log-level TRACE` → argparse error, no cluster
      start.