### PR TITLE
docs(README): add depthcache rot + UBDCC deep-dive articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,6 +667,8 @@ Binds to `127.0.0.1:8080` by default and opens the UI in your browser; enter the
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [Why Your Binance Order Book Should Not Live Inside Your Bot](https://blog.technopathy.club/why-your-binance-order-book-should-not-live-inside-your-bot)
 - [Your Binance Order Book Is Wrong — Here's Why](https://blog.technopathy.club/your-binance-order-book-is-wrong-here-s-why)
+- [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours)
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books)
 - [UNICORN Binance Suite Article Series](https://blog.technopathy.club/series/unicorn-binance-suite)
 
 ## How to report Bugs or suggest Improvements?

--- a/llms.txt
+++ b/llms.txt
@@ -95,6 +95,11 @@ Runs as processes on a single machine or as pods on Kubernetes.
 - [UBRA](https://github.com/oliver-zehentleitner/unicorn-binance-rest-api) — REST API client used for depth snapshots.
 - [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard) — optional browser UI for live monitoring and management of a running UBDCC cluster: view status, spot desync, add/remove caches on the fly (`pip install ubdcc-dashboard` → `ubdcc-dashboard start`).
 
+## Related Articles
+
+- [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours) — 25-hour experiment showing how a naive depth cache accumulates orphaned/stale levels without lifecycle pruning; motivates UBDCC's freshness/trust model.
+- [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books) — architecture write-up of the trust-layer UBDCC implements (multi-node consensus, freshness guarantees, replica management).
+
 ## Docs
 
 - Repo: https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster


### PR DESCRIPTION
## Summary
- Add two new technopathy.club articles to the *Related Articles* section.

## New links
- https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours
- https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books

The rot experiment motivates UBDCC's freshness/trust model with hard data; the deep-dive describes the architecture itself.

## Test plan
- [x] README renders correctly on GitHub
- [x] Link targets are reachable