### PR TITLE
release(ubdcc): 0.8.1 hotfix — fix Windows ubdcc start (cwd backslash escape)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.8.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `ubdcc start` on Windows: `packages/ubdcc/ubdcc/cli.py` now embeds
+  `cwd` and `log_level` via `repr()` (`{cwd!r}`) into the `python -c`
+  command used to spawn mgmt / restapi / dcn services. The previous
+  `'{cwd}'` f-string interpolation emitted raw backslashes into the
+  child Python source, so a working directory like `c:\ubdcc-test`
+  was parsed with `\u` as a Unicode escape
+  (`\ubdcc` -> U+BDCC), pointing the child at a non-existent
+  path and crashing `os.chdir()` with `FileNotFoundError [WinError 2]`.
+  Linux/macOS were unaffected because POSIX paths have no backslashes.
 
 ## 0.8.0
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,14 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.8.0.dev (development stage/unreleased/unstable)
+## 0.9.0.dev (development stage/unreleased/unstable)
+
+## 0.8.1
+*Hotfix release — only the `ubdcc` CLI meta-package was bumped; the
+service packages (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`,
+`ubdcc-shared-modules`) stay at 0.8.0 because they are unchanged. The
+CLI pins them with `==0.8.0`.*
+
 ### Fixed
 - `ubdcc start` on Windows: `packages/ubdcc/ubdcc/cli.py` now embeds
   `cwd` and `log_level` via `repr()` (`{cwd!r}`) into the `python -c`

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 All notable changes to this package will be documented in this file.
 
-## 0.8.0.dev (development stage/unreleased/unstable)
+## 0.9.0.dev (development stage/unreleased/unstable)
+
+## 0.8.1
 ### Fixed
 - `ubdcc start` on Windows: `cwd` (and `log_level`) are now embedded
   via `repr()` (`{cwd!r}`) into the `python -c` command spawned for

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to this package will be documented in this file.
 
 ## 0.8.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `ubdcc start` on Windows: `cwd` (and `log_level`) are now embedded
+  via `repr()` (`{cwd!r}`) into the `python -c` command spawned for
+  mgmt / restapi / dcn services. The previous `'{cwd}'` interpolation
+  emitted raw backslashes into the child Python source, so a Windows
+  working directory like `c:\ubdcc-test` was parsed by the child as
+  the string literal `'c:\ubdcc-test'` with `\u` interpreted
+  as a Unicode escape (`\ubdcc` -> U+BDCC), yielding a
+  non-existent path and making `os.chdir()` fail with
+  `FileNotFoundError [WinError 2]`. Other backslash sequences
+  (`\n`, `\t`, `\b`, ...) were equally
+  broken. Linux/macOS were unaffected because POSIX paths have no
+  backslashes.
 
 ## 0.8.0
 ### Added

--- a/packages/ubdcc/pyproject.toml
+++ b/packages/ubdcc/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc"
-version = "0.8.0"
+version = "0.8.1"
 description = "UNICORN Binance DepthCache Cluster — cluster manager and meta-package"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"

--- a/packages/ubdcc/setup.py
+++ b/packages/ubdcc/setup.py
@@ -27,7 +27,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.8.0",
+    version="0.8.1",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",

--- a/packages/ubdcc/ubdcc/__init__.py
+++ b/packages/ubdcc/ubdcc/__init__.py
@@ -17,4 +17,4 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"

--- a/packages/ubdcc/ubdcc/cli.py
+++ b/packages/ubdcc/ubdcc/cli.py
@@ -109,7 +109,7 @@ def cmd_start(args):
     dcn_count = args.dcn
     logdir = args.logdir if args.logdir else UBS_LOGS
     log_level = args.log_level
-    log_level_kwarg = f", log_level='{log_level}'" if log_level else ""
+    log_level_kwarg = f", log_level={log_level!r}" if log_level else ""
     os.makedirs(logdir, exist_ok=True)
     save_port(mgmt_port)
 
@@ -126,7 +126,7 @@ def cmd_start(args):
         proc = subprocess.Popen(
             [sys.executable, "-c",
              f"import os; from ubdcc_mgmt.Mgmt import Mgmt; "
-             f"Mgmt(cwd='{cwd}', mgmt_port={mgmt_port}{log_level_kwarg})"],
+             f"Mgmt(cwd={cwd!r}, mgmt_port={mgmt_port}{log_level_kwarg})"],
             stdout=log, stderr=subprocess.STDOUT
         )
         # Remove old mgmt from processes list
@@ -142,7 +142,7 @@ def cmd_start(args):
         proc = subprocess.Popen(
             [sys.executable, "-c",
              f"import os; from ubdcc_restapi.RestApi import RestApi; "
-             f"RestApi(cwd='{cwd}', mgmt_port={mgmt_port}{log_level_kwarg})"],
+             f"RestApi(cwd={cwd!r}, mgmt_port={mgmt_port}{log_level_kwarg})"],
             stdout=log, stderr=subprocess.STDOUT
         )
         # Remove old restapi from processes list
@@ -160,7 +160,7 @@ def cmd_start(args):
         proc = subprocess.Popen(
             [sys.executable, "-c",
              f"import os; from ubdcc_dcn.DepthCacheNode import DepthCacheNode; "
-             f"DepthCacheNode(cwd='{cwd}', mgmt_port={mgmt_port}{log_level_kwarg})"],
+             f"DepthCacheNode(cwd={cwd!r}, mgmt_port={mgmt_port}{log_level_kwarg})"],
             stdout=log, stderr=subprocess.STDOUT
         )
         processes.append((f"dcn-{nr}", proc, log))


### PR DESCRIPTION
## Summary
Hotfix release **0.8.1** for the `ubdcc` CLI meta-package — fixes `ubdcc start` crashing on Windows with `FileNotFoundError [WinError 2]`.

## The bug
In `packages/ubdcc/ubdcc/cli.py`, `cwd` was interpolated as `'{cwd}'` into a `python -c` source string. On Windows, paths contain backslashes — a working directory like `c:\ubdcc-test` was parsed by the child interpreter with `\u` as a Unicode escape (`\ubdcc` -> U+BDCC), yielding a non-existent path. The child's `os.chdir()` then crashed.

## The fix
Use `repr()` (`{cwd!r}` / `{log_level!r}`) when embedding into the spawned `-c` source. Python emits a properly escaped string literal. Applied to all three spawn helpers (mgmt, restapi, dcn) plus `log_level_kwarg`.

## Release scope (intentionally narrow)
Only the `ubdcc` CLI meta-package is bumped to **0.8.1**. Service packages (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`, `ubdcc-shared-modules`) stay at **0.8.0** because their code is unchanged. The CLI's `install_requires` keeps `==0.8.0` pins on them, so `pip install -U ubdcc` on a Windows user's box only pulls the new CLI wheel — minimal disruption.

`dev/set_version_config.yml` stays at `version: 0.8.0` so the next suite-wide `set_version.py` run still finds and bumps the service packages. The three CLI files now at 0.8.1 will need manual handling on the next suite-wide bump (or a config split later).

## Files touched
- `packages/ubdcc/ubdcc/cli.py` — the actual fix
- `packages/ubdcc/setup.py`, `packages/ubdcc/pyproject.toml`, `packages/ubdcc/ubdcc/__init__.py` — version bump (selbst-version only, sub-pins unchanged)
- `CHANGELOG.md`, `packages/ubdcc/CHANGELOG.md` — `0.8.0.dev` -> `0.9.0.dev` + new `0.8.1` section

## Repro (Windows)
```
mkdir c:\ubdcc-test
cd c:\ubdcc-test
ubdcc start --dcn=6
```
Without the fix: `~\.unicorn-binance-suite\logs\ubdcc-*.log` shows `FileNotFoundError [WinError 2]`.

## Test plan
- [ ] On Windows, repro recipe above brings up mgmt + restapi + 6 DCNs cleanly
- [ ] On Linux, `ubdcc start --dcn=2` still works (no regression)
- [ ] After PyPI release: `pip install -U ubdcc` on Windows user box installs only `ubdcc-0.8.1`, services remain at 0.8.0
