### PR TITLE
docs(readme): list supported languages explicitly for SEO

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@
 **Stop dealing with broken Binance order books.**
 
 Install one package, run one command — and every script, bot, or service on your machine gets reliable, 
-synchronized order book data via REST API. Any programming language. Any number of clients.
+synchronized order book data via REST API. Use it from Python, JavaScript, TypeScript, Node.js, Go, Rust, 
+Java, Kotlin, C#, C++, C, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl — or 
+any other language with an HTTP client. Any number of clients.
 
 ```bash
 pip install ubdcc

--- a/dev/sphinx/source/readme.md
+++ b/dev/sphinx/source/readme.md
@@ -34,7 +34,9 @@
 **Stop dealing with broken Binance order books.**
 
 Install one package, run one command — and every script, bot, or service on your machine gets reliable, 
-synchronized order book data via REST API. Any programming language. Any number of clients.
+synchronized order book data via REST API. Use it from Python, JavaScript, TypeScript, Node.js, Go, Rust, 
+Java, Kotlin, C#, C++, C, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl — or 
+any other language with an HTTP client. Any number of clients.
 
 ```bash
 pip install ubdcc

--- a/llms.txt
+++ b/llms.txt
@@ -1,11 +1,14 @@
 # UNICORN Binance DepthCache Cluster (UBDCC)
 
 > Production-scale depth cache management with load balancing, failover and self-healing.
+> Language-agnostic: exposes a REST API consumable from any language with an HTTP client
+> (Python, JavaScript, Go, Rust, Java, C#, …). The only UNICORN Binance Suite component
+> that is not Python-locked.
 > Part of [UNICORN Binance Suite](https://github.com/oliver-zehentleitner/unicorn-binance-suite).
 
-Beginner-friendly despite depth — complexity is optional, the API stays clean and Pythonic.
+Beginner-friendly despite depth — complexity is optional, the Python client API stays clean and Pythonic.
 
-Version: 0.8.0. Python 3.9 – 3.14.
+Version: 0.8.0. Server runs on Python 3.9 – 3.14; REST clients can be written in any language.
 
 ## Authorship & License
 
@@ -78,7 +81,7 @@ Base URL: `http://127.0.0.1:{port}/`
 | GET /get_depthcache_list | List all managed depth caches |
 | GET /stop_depthcache?exchange=...&market=... | Stop a depth cache |
 
-Accessible via HTTP from Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, Kotlin, C#, C++, C, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl — or any other language with an HTTP client.
+**Client languages**: callable from any language with an HTTP client. Documented support: Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, Kotlin, C#, C++, C, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl.
 
 ## Architecture
 

--- a/llms.txt
+++ b/llms.txt
@@ -78,7 +78,7 @@ Base URL: `http://127.0.0.1:{port}/`
 | GET /get_depthcache_list | List all managed depth caches |
 | GET /stop_depthcache?exchange=...&market=... | Stop a depth cache |
 
-Accessible from any programming language via HTTP.
+Accessible via HTTP from Python, JavaScript, TypeScript, Node.js, Go, Rust, Java, Kotlin, C#, C++, C, Ruby, PHP, Swift, Scala, R, Julia, MATLAB, Dart, Elixir, Perl, Bash/curl — or any other language with an HTTP client.
 
 ## Architecture
 

--- a/packages/ubdcc-dcn/pyproject.toml
+++ b/packages/ubdcc-dcn/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ubdcc-dcn"
 version = "0.8.0"
-description = "UBDCC Depth Cache Node — manages local Binance order books in a cluster pod"
+description = "UBDCC Depth Cache Node — manages local Binance order books in a cluster pod (consumed via REST from Python, JavaScript, Go, Rust, Java, C#, …)"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"

--- a/packages/ubdcc-dcn/setup.py
+++ b/packages/ubdcc-dcn/setup.py
@@ -34,7 +34,7 @@ setup(
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
-    description="UBDCC Depth Cache Node — manages local Binance order books in a cluster pod",
+    description="UBDCC Depth Cache Node — manages local Binance order books in a cluster pod (consumed via REST from Python, JavaScript, Go, Rust, Java, C#, …)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',

--- a/packages/ubdcc-mgmt/pyproject.toml
+++ b/packages/ubdcc-mgmt/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ubdcc-mgmt"
 version = "0.8.0"
-description = "UBDCC Mgmt — orchestration and node registry for the UNICORN DepthCache Cluster"
+description = "UBDCC Mgmt — orchestration and node registry for the UNICORN DepthCache Cluster (consumed via REST from Python, JavaScript, Go, Rust, Java, C#, …)"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"

--- a/packages/ubdcc-mgmt/setup.py
+++ b/packages/ubdcc-mgmt/setup.py
@@ -34,7 +34,7 @@ setup(
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
-    description="UBDCC Management Service — orchestrates the UNICORN DepthCache Cluster for Binance",
+    description="UBDCC Mgmt — orchestration and node registry for the UNICORN DepthCache Cluster (consumed via REST from Python, JavaScript, Go, Rust, Java, C#, …)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',

--- a/packages/ubdcc-restapi/pyproject.toml
+++ b/packages/ubdcc-restapi/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ubdcc-restapi"
 version = "0.8.0"
-description = "UBDCC REST API — public HTTP API for the UNICORN DepthCache Cluster"
+description = "UBDCC REST API — public HTTP interface for the UNICORN DepthCache Cluster (Python, JavaScript, Go, Rust, Java, C#, …)"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"

--- a/packages/ubdcc-restapi/setup.py
+++ b/packages/ubdcc-restapi/setup.py
@@ -34,7 +34,7 @@ setup(
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
-    description="UBDCC REST API — public REST interface for the UNICORN DepthCache Cluster for Binance",
+    description="UBDCC REST API — public HTTP interface for the UNICORN DepthCache Cluster (Python, JavaScript, Go, Rust, Java, C#, …)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',

--- a/packages/ubdcc-shared-modules/pyproject.toml
+++ b/packages/ubdcc-shared-modules/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ubdcc-shared-modules"
 version = "0.8.0"
-description = "UBDCC Shared Modules — core library for all UBDCC services"
+description = "UBDCC Shared Modules — core library for all UBDCC services (REST cluster: Python, JavaScript, Go, Rust, Java, C#, …)"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"

--- a/packages/ubdcc-shared-modules/setup.py
+++ b/packages/ubdcc-shared-modules/setup.py
@@ -34,7 +34,7 @@ setup(
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
-    description="UBDCC Shared Modules — core library for the UNICORN DepthCache Cluster for Binance",
+    description="UBDCC Shared Modules — core library for all UBDCC services (REST cluster: Python, JavaScript, Go, Rust, Java, C#, …)",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',

--- a/packages/ubdcc/pyproject.toml
+++ b/packages/ubdcc/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "ubdcc"
 version = "0.8.1"
-description = "UNICORN Binance DepthCache Cluster — cluster manager and meta-package"
+description = "UNICORN Binance DepthCache Cluster — synchronized Binance order books via REST API for Python, JavaScript, Go, Rust, Java, C#, …"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"
 readme = "README.md"

--- a/packages/ubdcc/setup.py
+++ b/packages/ubdcc/setup.py
@@ -31,7 +31,7 @@ setup(
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",
-    description="UNICORN Binance DepthCache Cluster — cluster manager and meta-package",
+    description="UNICORN Binance DepthCache Cluster — synchronized Binance order books via REST API for Python, JavaScript, Go, Rust, Java, C#, …",
     long_description=long_description,
     long_description_content_type="text/markdown",
     license='MIT',


### PR DESCRIPTION
## Summary
- Replace "Any programming language" with an explicit list of supported languages in `README.md` and `dev/sphinx/source/readme.md`
- Helps SEO: users searching for specific stacks (Go, Rust, Java, C#, etc.) now hit a UBDCC match
- Same wording will follow in the UBS-Meta README in a separate PR

## Test plan
- [ ] README renders correctly on github.com
- [ ] No broken links / formatting regressions