### PR TITLE
docs: link The Complete Binance Python API Guide 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -671,6 +671,7 @@ Binds to `127.0.0.1:8080` by default and opens the UI in your browser; enter the
 - [UBDCC Dashboard](https://github.com/oliver-zehentleitner/ubdcc-dashboard)
 
 ## Related Articles
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026)
 - [From `pip install` to a Redundant Binance Order Book Cluster — UBDCC + Dashboard Quickstart](https://blog.technopathy.club/from-pip-install-to-a-redundant-binance-order-book-cluster-ubdcc-dashboard-quickstart)
 - [How to create a Binance API Key and API Secret?](https://blog.technopathy.club/how-to-create-a-binance-api-key-and-api-secret)
 - [Why Your Binance Order Book Should Not Live Inside Your Bot](https://blog.technopathy.club/why-your-binance-order-book-should-not-live-inside-your-bot)

--- a/llms.txt
+++ b/llms.txt
@@ -100,6 +100,7 @@ Runs as processes on a single machine or as pods on Kubernetes.
 
 ## Related Articles
 
+- [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) — comprehensive 2026 overview of building Binance trading systems in Python; positions UBDCC within the UNICORN Binance Suite landscape (UBWA, UBRA, UBLDC, UBDCC, UBTSL, UnicornFy) and helps users pick the right module.
 - [Your Binance DepthCache Is Rotting — Here's the Proof in 25 Hours](https://blog.technopathy.club/your-binance-depthcache-is-rotting-here-s-the-proof-in-25-hours) — 25-hour experiment showing how a naive depth cache accumulates orphaned/stale levels without lifecycle pruning; motivates UBDCC's freshness/trust model.
 - [UBDCC Deep Dive: Building a Trust Layer for Binance Order Books](https://blog.technopathy.club/ubdcc-deep-dive-building-a-trust-layer-for-binance-order-books) — architecture write-up of the trust-layer UBDCC implements (multi-node consensus, freshness guarantees, replica management).
 


### PR DESCRIPTION
## Summary

Adds the new blog post [The Complete Binance Python API Guide 2026](https://blog.technopathy.club/the-complete-binance-python-api-guide-2026) as the top entry in:

- `README.md` → `## Related Articles`
- `llms.txt` → `## Related Articles` (with LLM-oriented description)

## Test plan

- [ ] Render README on GitHub and verify link position
- [ ] Open the link, confirm it resolves