### PR TITLE
fix(docker): pin base image to python:3.12-slim

### DIFF
--- a/container/generic_loader/Dockerfile.ubdcc-dcn
+++ b/container/generic_loader/Dockerfile.ubdcc-dcn
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 WORKDIR /app/generic_loader
 

--- a/container/generic_loader/Dockerfile.ubdcc-mgmt
+++ b/container/generic_loader/Dockerfile.ubdcc-mgmt
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 WORKDIR /app/generic_loader
 

--- a/container/generic_loader/Dockerfile.ubdcc-restapi
+++ b/container/generic_loader/Dockerfile.ubdcc-restapi
@@ -1,4 +1,4 @@
-FROM python:3.14-slim
+FROM python:3.12-slim
 
 WORKDIR /app/generic_loader
 


### PR DESCRIPTION
## Summary
- Switch all three UBDCC container images (`dcn`, `mgmt`, `restapi`) from `python:3.14-slim` to `python:3.12-slim`
- Works around certificate issues observed with the current 3.14 base image on Kubernetes (Vultr)

## Test plan
- [ ] GitHub Action builds all three images successfully
- [ ] Pods start cleanly in the Vultr k8s cluster
- [ ] No TLS/cert errors during `pip install` at container start