### PR TITLE
feat(k8s): UBDCC_K8S_VERIFY_SSL env var to opt out of TLS verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.9.0.dev (development stage/unreleased/unstable)
+### Added
+- `UBDCC_K8S_VERIFY_SSL` environment variable (default `"true"`) for the
+  three services (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`). Set to
+  `"false"` to disable TLS verification for the in-cluster Kubernetes API
+  calls made by `get_k8s_runtime_information()` /
+  `get_k8s_nodes()` in
+  `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py`. Intended
+  as an opt-out for clusters that ship Kubernetes API server certificates
+  rejected by strict X.509 verification (e.g. missing
+  AuthorityKeyIdentifier, `keyCertSign` set on a non-CA cert — observed
+  on some managed clusters). The flag is wired through the Helm chart
+  (`dev/helm/ubdcc/values.yaml`: `k8s.verifySsl`) and the raw Kubernetes
+  manifests in `admin/k8s/`. When set to `false`, a `WARNING` is logged
+  on every service start and urllib3's `InsecureRequestWarning` is
+  silenced.
 
 ## 0.8.1
 *Hotfix release — only the `ubdcc` CLI meta-package was bumped; the

--- a/admin/k8s/ubdcc-dcn.yaml
+++ b/admin/k8s/ubdcc-dcn.yaml
@@ -15,3 +15,10 @@ spec:
       containers:
         - name: ubdcc-dcn
           image: ghcr.io/oliver-zehentleitner/ubdcc-dcn:0.8.0
+          # Set UBDCC_K8S_VERIFY_SSL to "false" only if your cluster's
+          # Kubernetes API server certificate is rejected by strict X.509
+          # verification. This disables TLS verification for the in-cluster
+          # Kubernetes API calls and is INSECURE - use with care.
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: "true"

--- a/admin/k8s/ubdcc-mgmt.yaml
+++ b/admin/k8s/ubdcc-mgmt.yaml
@@ -26,6 +26,13 @@ spec:
           ports:
             - name: rest-private
               containerPort: 8080
+          # Set UBDCC_K8S_VERIFY_SSL to "false" only if your cluster's
+          # Kubernetes API server certificate is rejected by strict X.509
+          # verification. This disables TLS verification for the in-cluster
+          # Kubernetes API calls and is INSECURE - use with care.
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: "true"
           resources:
             requests:
               cpu: "250m"

--- a/admin/k8s/ubdcc-restapi.yaml
+++ b/admin/k8s/ubdcc-restapi.yaml
@@ -32,6 +32,13 @@ spec:
           ports:
             - name: rest-private
               containerPort: 8080
+          # Set UBDCC_K8S_VERIFY_SSL to "false" only if your cluster's
+          # Kubernetes API server certificate is rejected by strict X.509
+          # verification. This disables TLS verification for the in-cluster
+          # Kubernetes API calls and is INSECURE - use with care.
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: "true"
           resources:
             requests:
               cpu: "250m"

--- a/dev/helm/ubdcc/templates/ubdcc-dcn.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-dcn.yaml
@@ -15,3 +15,6 @@ spec:
       containers:
         - name: {{ .Values.name.dcn }}
           image: "ghcr.io/oliver-zehentleitner/ubdcc-dcn:{{ .Chart.AppVersion }}"
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: {{ .Values.k8s.verifySsl | quote }}

--- a/dev/helm/ubdcc/templates/ubdcc-mgmt.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-mgmt.yaml
@@ -26,6 +26,9 @@ spec:
           ports:
             - name: rest-private
               containerPort: 8080
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: {{ .Values.k8s.verifySsl | quote }}
           resources:
             requests:
               cpu: "250m"

--- a/dev/helm/ubdcc/templates/ubdcc-restapi.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-restapi.yaml
@@ -32,6 +32,9 @@ spec:
           ports:
             - name: rest-private
               containerPort: 8080
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: {{ .Values.k8s.verifySsl | quote }}
           resources:
             requests:
               cpu: "250m"

--- a/dev/helm/ubdcc/values.yaml
+++ b/dev/helm/ubdcc/values.yaml
@@ -9,3 +9,10 @@ replicaCount:
 
 publicPort:
   restapi: 80
+
+k8s:
+  # Set to "false" only if your cluster's Kubernetes API server certificate
+  # is rejected by strict X.509 verification (e.g. missing AuthorityKeyIdentifier,
+  # keyCertSign on a non-CA cert). This disables TLS verification for the
+  # in-cluster Kubernetes API calls and is INSECURE - use with care.
+  verifySsl: "true"

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,21 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.9.0.dev (development stage/unreleased/unstable)
+### Added
+- `UBDCC_K8S_VERIFY_SSL` environment variable (default `"true"`) for the
+  three services (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`). Set to
+  `"false"` to disable TLS verification for the in-cluster Kubernetes API
+  calls made by `get_k8s_runtime_information()` /
+  `get_k8s_nodes()` in
+  `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py`. Intended
+  as an opt-out for clusters that ship Kubernetes API server certificates
+  rejected by strict X.509 verification (e.g. missing
+  AuthorityKeyIdentifier, `keyCertSign` set on a non-CA cert — observed
+  on some managed clusters). The flag is wired through the Helm chart
+  (`dev/helm/ubdcc/values.yaml`: `k8s.verifySsl`) and the raw Kubernetes
+  manifests in `admin/k8s/`. When set to `false`, a `WARNING` is logged
+  on every service start and urllib3's `InsecureRequestWarning` is
+  silenced.
 
 ## 0.8.1
 *Hotfix release — only the `ubdcc` CLI meta-package was bumped; the

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -196,6 +196,20 @@ class App:
     def get_k8s_runtime_information(self):
         try:
             kubernetes.config.load_incluster_config()
+            verify_ssl_env = os.getenv("UBDCC_K8S_VERIFY_SSL", "true").strip().lower()
+            if verify_ssl_env in ("false", "0", "no", "off"):
+                self.stdout_msg(
+                    "WARNING: UBDCC_K8S_VERIFY_SSL=false - TLS verification for the Kubernetes API "
+                    "is DISABLED. This is insecure and should only be used for clusters with broken "
+                    "API server certificates.", log="warn")
+                configuration = kubernetes.client.Configuration.get_default_copy()
+                configuration.verify_ssl = False
+                kubernetes.client.Configuration.set_default(configuration)
+                try:
+                    import urllib3
+                    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+                except Exception:
+                    pass
             with open("/etc/hostname", "r") as f:
                 pod_name = f.read().strip()
             with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:


### PR DESCRIPTION
## Summary
- Adds opt-in env var `UBDCC_K8S_VERIFY_SSL` (default `"true"`) to all
  three services (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`)
- Set to `"false"` to disable TLS verification for the in-cluster
  Kubernetes API calls (used by `get_k8s_runtime_information()` and
  `get_k8s_nodes()` in `ubdcc_shared_modules/App.py`)
- Unblocks UBDCC on clusters that ship K8s API server certs which fail
  strict X.509 verification (observed on Vultr Kubernetes: invalid CA,
  `keyCertSign` on non-CA cert, missing AuthorityKeyIdentifier)
- Helm chart: `k8s.verifySsl` value
- Raw manifests in `admin/k8s/`: env section with `"true"` default

Default behavior is unchanged (verification stays on). When disabled, a
loud `WARNING` is logged on every service start.

## Test plan
- [ ] Deploy with default (`UBDCC_K8S_VERIFY_SSL` unset or `"true"`) →
      behavior identical to before
- [ ] Deploy on the Vultr cluster with `UBDCC_K8S_VERIFY_SSL=false` →
      `ubdcc-mgmt` no longer crashes in `get_k8s_runtime_information()`
- [ ] Confirm WARNING log line appears at startup when disabled