### PR TITLE
chore(release): prepare 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.9.0.dev (development stage/unreleased/unstable)
+## 0.9.0
 ### Added
 - `UBDCC_K8S_VERIFY_SSL` environment variable (default `"true"`) for the
   three services (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`). Set to

--- a/dev/set_version_config.yml
+++ b/dev/set_version_config.yml
@@ -32,4 +32,5 @@ files:
 - packages/ubdcc-shared-modules/setup.py
 - README.md
 - AGENTS.md
+- llms.txt
 version: 0.8.0

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
-## 0.9.0.dev (development stage/unreleased/unstable)
+## 0.9.0
 ### Added
 - `UBDCC_K8S_VERIFY_SSL` environment variable (default `"true"`) for the
   three services (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`). Set to

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this package will be documented in this file.
 
+## 0.9.0
+### Added
+- `UBDCC_K8S_VERIFY_SSL` environment variable (default `"true"`) for
+  `get_k8s_runtime_information()`. When set to `"false"`, TLS
+  verification is disabled for the in-cluster Kubernetes API calls and
+  a `WARNING` is logged on every service start. Intended as an opt-out
+  for clusters with broken API server certificates (e.g. missing
+  AuthorityKeyIdentifier, `keyCertSign` on a non-CA cert).
+
 ## 0.8.0.dev (development stage/unreleased/unstable)
 
 ## 0.8.0

--- a/packages/ubdcc/CHANGELOG.md
+++ b/packages/ubdcc/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 All notable changes to this package will be documented in this file.
 
-## 0.9.0.dev (development stage/unreleased/unstable)
+## 0.9.0
+### Added
+- `UBDCC_K8S_VERIFY_SSL` environment variable propagated to all three
+  services (`ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`). See main
+  `CHANGELOG.md` for details.
 
 ## 0.8.1
 ### Fixed

--- a/packages/ubdcc/pyproject.toml
+++ b/packages/ubdcc/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ubdcc"
-version = "0.8.1"
+version = "0.9.0"
 description = "UNICORN Binance DepthCache Cluster — synchronized Binance order books via REST API for Python, JavaScript, Go, Rust, Java, C#, …"
 authors = ["Oliver Zehentleitner <>"]
 license = "MIT"

--- a/packages/ubdcc/setup.py
+++ b/packages/ubdcc/setup.py
@@ -27,7 +27,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name=name,
-    version="0.8.1",
+    version="0.9.0",
     author="Oliver Zehentleitner",
     author_email='',
     url="https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster",

--- a/packages/ubdcc/ubdcc/__init__.py
+++ b/packages/ubdcc/ubdcc/__init__.py
@@ -17,4 +17,4 @@
 # Copyright (c) 2024-2026, Oliver Zehentleitner (https://about.me/oliver-zehentleitner)
 # All rights reserved.
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"


### PR DESCRIPTION
## Summary
Manual pre-bumps for the upcoming `set_version.py 0.9.0` run. After
merging this, run:

```
python dev/set_version.py 0.9.0
```

to bump every remaining `0.8.0` reference in the configured file list
(setup.py / pyproject.toml / requirements.txt / workflows / k8s
manifests / Chart.yaml / conf.py / App.py / README.md / AGENTS.md /
llms.txt).

### What this PR does
- `packages/ubdcc` (CLI meta): `0.8.1` → `0.9.0` in `setup.py`,
  `pyproject.toml`, `__init__.py`. The CLI was at `0.8.1` from the
  Windows-path hotfix and `set_version.py` only replaces the configured
  `0.8.0` search string, so these three lines need a manual bump.
- `CHANGELOG.md` / `dev/sphinx/source/changelog.md`: `## 0.9.0.dev`
  header promoted to `## 0.9.0`. No new `.dev` header introduced
  (matches the UBLDC pattern).
- `packages/ubdcc-shared-modules/CHANGELOG.md`: 0.9.0 entry documenting
  the `UBDCC_K8S_VERIFY_SSL` env var added in #153.
- `packages/ubdcc/CHANGELOG.md`: 0.9.0 stub pointing at the main
  CHANGELOG.
- `dev/set_version_config.yml`: `llms.txt` added to the file list so
  its `Version: 0.8.0.` line gets bumped together with the rest.

### Release pipeline after merge
1. `python dev/set_version.py 0.9.0` (locally or via the workflow)
2. Build wheels & upload to PyPI for `ubdcc-shared-modules`,
   `ubdcc-mgmt`, `ubdcc-restapi`, `ubdcc-dcn`, `ubdcc`
3. Trigger `docker_build.yml` with `version: 0.9.0`
4. Update Vultr deployment with `UBDCC_K8S_VERIFY_SSL: "false"`

## Test plan
- [ ] `python dev/set_version.py 0.9.0` produces a clean diff
      (no remaining `0.8.0` references in tracked files outside CHANGELOGs)
- [ ] Wheels build & upload for all 5 packages
- [ ] Docker images `ubdcc-{mgmt,dcn,restapi}:0.9.0` build successfully