### PR TITLE
fix(k8s): preserve Bearer token when UBDCC_K8S_VERIFY_SSL=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.9.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `get_k8s_runtime_information()` in
+  `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py`: the
+  in-cluster Kubernetes API client lost its Bearer token when
+  `UBDCC_K8S_VERIFY_SSL=false` was set, causing every API request to
+  hit the API server as `system:anonymous` and fall back to dev mode
+  (random pod identity + `localhost:42080` mgmt routing). The previous
+  flow loaded the in-cluster config, then created a copy via
+  `Configuration.get_default_copy()`, mutated `verify_ssl=False` on the
+  copy, and pushed it back via `Configuration.set_default()`; in the
+  pinned kubernetes-client version this swap dropped the
+  `api_key['authorization']` Bearer header. New flow: pre-create a
+  `kubernetes.client.Configuration()`, set `verify_ssl=False` on it
+  *before* calling
+  `kubernetes.config.load_incluster_config(client_configuration=cfg)`
+  so the lib writes the token directly into the already-modified
+  Configuration, then instantiate `CoreV1Api` / `CustomObjectsApi`
+  with an explicit `ApiClient(configuration=cfg)` — no more global
+  default-swap. Verified out-of-band with a raw urllib request from
+  inside the pod (`HTTP 200`, real pod JSON) on a Vultr Kubernetes
+  cluster where the previous code path returned 403.
 
 ## 0.9.0
 ### Added

--- a/dev/sphinx/source/changelog.md
+++ b/dev/sphinx/source/changelog.md
@@ -10,6 +10,27 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.9.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `get_k8s_runtime_information()` in
+  `packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py`: the
+  in-cluster Kubernetes API client lost its Bearer token when
+  `UBDCC_K8S_VERIFY_SSL=false` was set, causing every API request to
+  hit the API server as `system:anonymous` and fall back to dev mode
+  (random pod identity + `localhost:42080` mgmt routing). The previous
+  flow loaded the in-cluster config, then created a copy via
+  `Configuration.get_default_copy()`, mutated `verify_ssl=False` on the
+  copy, and pushed it back via `Configuration.set_default()`; in the
+  pinned kubernetes-client version this swap dropped the
+  `api_key['authorization']` Bearer header. New flow: pre-create a
+  `kubernetes.client.Configuration()`, set `verify_ssl=False` on it
+  *before* calling
+  `kubernetes.config.load_incluster_config(client_configuration=cfg)`
+  so the lib writes the token directly into the already-modified
+  Configuration, then instantiate `CoreV1Api` / `CustomObjectsApi`
+  with an explicit `ApiClient(configuration=cfg)` — no more global
+  default-swap. Verified out-of-band with a raw urllib request from
+  inside the pod (`HTTP 200`, real pod JSON) on a Vultr Kubernetes
+  cluster where the previous code path returned 403.
 
 ## 0.9.0
 ### Added

--- a/packages/ubdcc-shared-modules/CHANGELOG.md
+++ b/packages/ubdcc-shared-modules/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this package will be documented in this file.
 
+## 0.9.0.dev (development stage/unreleased/unstable)
+### Fixed
+- `get_k8s_runtime_information()`: the in-cluster Kubernetes API client
+  lost its Bearer token when `UBDCC_K8S_VERIFY_SSL=false` was set,
+  causing every API request to be sent as `system:anonymous` (403) and
+  the service to fall into dev mode. Configuration is now pre-built
+  with `verify_ssl=False`, passed into
+  `load_incluster_config(client_configuration=cfg)` so the lib writes
+  the token directly into it, and the API clients are instantiated with
+  an explicit `ApiClient(configuration=cfg)` — no more global
+  default-swap that dropped the auth header.
+
 ## 0.9.0
 ### Added
 - `UBDCC_K8S_VERIFY_SSL` environment variable (default `"true"`) for

--- a/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
+++ b/packages/ubdcc-shared-modules/ubdcc_shared_modules/App.py
@@ -195,27 +195,28 @@ class App:
 
     def get_k8s_runtime_information(self):
         try:
-            kubernetes.config.load_incluster_config()
             verify_ssl_env = os.getenv("UBDCC_K8S_VERIFY_SSL", "true").strip().lower()
-            if verify_ssl_env in ("false", "0", "no", "off"):
+            verify_ssl_disabled = verify_ssl_env in ("false", "0", "no", "off")
+            configuration = kubernetes.client.Configuration()
+            if verify_ssl_disabled:
                 self.stdout_msg(
                     "WARNING: UBDCC_K8S_VERIFY_SSL=false - TLS verification for the Kubernetes API "
                     "is DISABLED. This is insecure and should only be used for clusters with broken "
                     "API server certificates.", log="warn")
-                configuration = kubernetes.client.Configuration.get_default_copy()
                 configuration.verify_ssl = False
-                kubernetes.client.Configuration.set_default(configuration)
                 try:
                     import urllib3
                     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
                 except Exception:
                     pass
+            kubernetes.config.load_incluster_config(client_configuration=configuration)
             with open("/etc/hostname", "r") as f:
                 pod_name = f.read().strip()
             with open("/var/run/secrets/kubernetes.io/serviceaccount/namespace", "r") as f:
                 namespace = f.read().strip()
-            self.k8s_client = kubernetes.client.CoreV1Api()
-            self.k8s_metrics_client = kubernetes.client.CustomObjectsApi()
+            api_client = kubernetes.client.ApiClient(configuration=configuration)
+            self.k8s_client = kubernetes.client.CoreV1Api(api_client=api_client)
+            self.k8s_metrics_client = kubernetes.client.CustomObjectsApi(api_client=api_client)
             self.pod_info = self.k8s_client.read_namespaced_pod(name=pod_name, namespace=namespace)
             self.node_info = self.k8s_client.read_node(self.pod_info.spec.node_name)
         except kubernetes.client.exceptions.ApiException as error_msg:


### PR DESCRIPTION
## Summary
The 0.9.0 `UBDCC_K8S_VERIFY_SSL=false` opt-out shipped a regression:
the in-cluster Kubernetes API client lost its ServiceAccount Bearer
token when verification was disabled, so every API request hit the
API server as `system:anonymous` and returned 403. All three services
(`mgmt`, `restapi`, `dcn`) then fell into dev mode — random pod
identity + `localhost:42080` mgmt routing → no node registration.

## Root cause
`Configuration.get_default_copy()` + mutate + `Configuration.set_default(modified)`:
on the pinned `kubernetes-client` version, this swap drops
`api_key['authorization']` from the published Configuration. TLS
verification gets disabled — and the auth header goes with it.

## Fix
Pre-build a `kubernetes.client.Configuration()`, set `verify_ssl=False`
on it *before* calling
`kubernetes.config.load_incluster_config(client_configuration=cfg)` so
the lib writes the token directly into the already-modified
Configuration. Instantiate `CoreV1Api` / `CustomObjectsApi` with an
explicit `ApiClient(configuration=cfg)` — no more global default-swap.

## Verification
Out-of-band reproducer from inside a restapi pod on the affected
Vultr cluster:
- raw urllib + token + `ssl.CERT_NONE` → `HTTP 200`, real pod JSON
- old code path → `HTTP 403 system:anonymous`

After the fix, the same code path the lib uses should also return 200.

## Test plan
- [ ] Rebuild & deploy `ubdcc-{mgmt,restapi,dcn}` with the patch
- [ ] `UBDCC_K8S_VERIFY_SSL=false` set in all three deployments
- [ ] Logs show `WARNING: UBDCC_K8S_VERIFY_SSL=false ...` *and* real
      pod info (no random strings, no "DEV MODE")
- [ ] restapi/dcn register at the cluster mgmt service (not localhost)

## Out of scope
Version bump. The `0.9.0.dev` header stays. After merge, run
`python dev/set_version.py 0.9.1` (with `version: 0.9.0` as
search-string in the config) for the release.