### PR TITLE
feat(k8s): add ubdcc-dcn Deployment variant for N pods per node

### DIFF
--- a/admin/k8s/ubdcc-dcn-deployment.yaml
+++ b/admin/k8s/ubdcc-dcn-deployment.yaml
@@ -1,0 +1,39 @@
+# Alternative to ubdcc-dcn.yaml (DaemonSet, 1 pod per node).
+# Use this variant when you want N pods per node (e.g. 2 per node so each DCN
+# pins to a CPU core). Pick ONE of the two manifests — do NOT apply both.
+#
+# Pod count is set via `replicas` (= desired-per-node * node-count).
+# `topologySpreadConstraints` with maxSkew: 1 enforces an even distribution
+# across nodes, so with replicas = 2 * node-count you get exactly 2 per node.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ubdcc-dcn
+  namespace: ubdcc
+spec:
+  replicas: 6                       # = 2 × node-count (adjust to your cluster)
+  selector:
+    matchLabels:
+      app: ubdcc-dcn
+  template:
+    metadata:
+      labels:
+        app: ubdcc-dcn
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: ubdcc-dcn
+      containers:
+        - name: ubdcc-dcn
+          image: ghcr.io/oliver-zehentleitner/ubdcc-dcn:0.9.1
+          # Set UBDCC_K8S_VERIFY_SSL to "false" only if your cluster's
+          # Kubernetes API server certificate is rejected by strict X.509
+          # verification. This disables TLS verification for the in-cluster
+          # Kubernetes API calls and is INSECURE - use with care.
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: "false"


### PR DESCRIPTION
## Summary
DaemonSet is by-design "1 pod per node" with no \`replicasPerNode\`
knob. For deployments that want **N DCN pods per node** (e.g. one per
CPU core), this PR adds an alternative manifest
\`admin/k8s/ubdcc-dcn-deployment.yaml\` next to the existing DaemonSet
manifest.

### How it works
- \`kind: Deployment\` with \`replicas = desired-per-node × node-count\`
- \`topologySpreadConstraints\` with \`maxSkew: 1\` and
  \`whenUnsatisfiable: DoNotSchedule\` forces even distribution across
  nodes — with \`replicas: 2 * node-count\` you get exactly 2 pods per
  node, no "all 6 land on one node" edge cases.
- Same \`metadata.name: ubdcc-dcn\` as the DaemonSet manifest, so
  **exactly one of the two must be applied** — header comment in the
  new file warns about that explicitly.
- \`image\` + \`UBDCC_K8S_VERIFY_SSL\` env var carried over 1:1 from
  \`admin/k8s/ubdcc-dcn.yaml\`.

### Why not modify the DaemonSet
The default install path (1 DCN per node) should stay trivial — most
clusters won't need more than 1 per node. Adding the Deployment as a
sibling manifest keeps both options reachable without forcing users
to choose one before they read the README.

### Out of scope
Helm chart update — current Helm template ships only the DaemonSet
variant. Can add a \`values.yaml\` toggle later if there's demand
(\`k8s.dcn.mode: daemonset|deployment\`).

## Test plan
- [ ] \`kubectl apply -f admin/k8s/ubdcc-dcn-deployment.yaml\` on a
      cluster with N nodes → exactly \`replicas / N\` DCN pods land on
      each node
- [ ] Verify pods register at mgmt and start serving DepthCaches