### PR TITLE
feat(helm): optional N DCN pods per node via dcn.coresPerNode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 [How to upgrade to the latest version!](https://oliver-zehentleitner.github.io/unicorn-binance-depth-cache-cluster/readme.html#installation-and-upgrade)
 
 ## 0.9.1.dev (development stage/unreleased/unstable)
+### Added
+- Helm chart: optional **N DCN pods per node** — the optimal distribution is one
+  DCN per CPU core. The default is unchanged (a `DaemonSet`, exactly 1 DCN pod
+  per node). Setting `dcn.coresPerNode > 1` switches the DCN to a `Deployment`
+  that auto-detects the count of schedulable, non-control-plane nodes via a
+  cluster `lookup` and renders `replicas = coresPerNode × nodeCount`, spread
+  evenly across nodes with `topologySpreadConstraints` (`maxSkew: 1`).
+- Helm values `dcn.coresPerNode`, `dcn.nodeCount` (override auto-detection),
+  `dcn.replicas` (force Deployment mode + override the whole calculation),
+  `dcn.nodeSelector` (pin DCN to a node pool) and `dcn.resources` (set
+  requests == limits for Guaranteed QoS / per-core CPU pinning).
 
 ## 0.9.1
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -529,7 +529,45 @@ helm install ubdcc ubdcc/ubdcc --namespace ubdcc
 ``` 
 helm install ubdcc ubdcc/ubdcc --set publicPort.restapi=8080
 ```
-  
+
+#### Scale DCN per CPU core
+By default the chart deploys the DCN as a `DaemonSet` — **exactly one DCN pod per node**. This
+auto-scales as you add or remove nodes and needs no extra permissions.
+
+Each DCN is a single Python process (GIL-bound), so **one DCN per CPU core** is the optimal
+distribution. To run more than one DCN per node, tell the chart how many cores your DCN nodes have:
+
+``` 
+helm install ubdcc ubdcc/ubdcc --set dcn.coresPerNode=4
+```
+
+With `coresPerNode > 1` the DCN becomes a `Deployment` whose pods are spread evenly across nodes
+(`topologySpreadConstraints`, `maxSkew: 1`). The node count is auto-detected from the cluster at
+install time (only schedulable, non control-plane nodes are counted), so
+`replicas = coresPerNode × nodeCount`. Auto-detection needs permission to list nodes for whoever
+runs `helm install`; on `helm template`/`--dry-run` it falls back to a single node.
+
+Override any level explicitly:
+
+``` 
+# fix the node count instead of auto-detecting
+helm install ubdcc ubdcc/ubdcc --set dcn.coresPerNode=4 --set dcn.nodeCount=3   # -> 12 DCN pods
+
+# set the total replica count directly (bypasses the calculation)
+helm install ubdcc ubdcc/ubdcc --set dcn.replicas=12
+
+# pin DCN to a dedicated node pool
+helm install ubdcc ubdcc/ubdcc --set dcn.coresPerNode=4 --set dcn.nodeSelector.role=dcn
+```
+
+For real per-core CPU pinning, give each pod a full core with Guaranteed QoS (requests == limits,
+integer cpu) — this requires the kubelet `cpuManagerPolicy: static` on your nodes:
+
+``` 
+helm install ubdcc ubdcc/ubdcc --set dcn.coresPerNode=4 \
+  --set dcn.resources.requests.cpu=1 --set dcn.resources.limits.cpu=1
+```
+
 ### Kubernetes Deployment
 - [Download the deployment files](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster/tree/master/admin/k8s)
 - Apply the deployment files with `kubectl`

--- a/dev/helm/ubdcc/templates/ubdcc-dcn.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-dcn.yaml
@@ -1,3 +1,73 @@
+{{- /*
+  DCN topology:
+  - Default (coresPerNode <= 1, no explicit replicas): a DaemonSet -> exactly
+    1 DCN pod per node. Auto-scales when nodes are added/removed, needs no
+    node lookup / cluster RBAC.
+  - coresPerNode > 1 (or an explicit dcn.replicas): a Deployment with
+    N pods per node, spread evenly across nodes (topologySpreadConstraints).
+    Replica precedence: dcn.replicas > coresPerNode × dcn.nodeCount >
+    coresPerNode × auto-detected nodes (schedulable, non-control-plane).
+    The lookup is empty on `helm template`/`--dry-run`, so it falls back to a
+    single node there.
+*/ -}}
+{{- $coresPerNode := .Values.dcn.coresPerNode | int -}}
+{{- $useDeployment := or (gt $coresPerNode 1) (ne (toString .Values.dcn.replicas) "") -}}
+{{- if $useDeployment -}}
+{{- $replicas := 0 -}}
+{{- if .Values.dcn.replicas -}}
+{{-   $replicas = .Values.dcn.replicas | int -}}
+{{- else -}}
+{{-   $nodeCount := 0 -}}
+{{-   if .Values.dcn.nodeCount -}}
+{{-     $nodeCount = .Values.dcn.nodeCount | int -}}
+{{-   else -}}
+{{-     range (lookup "v1" "Node" "" "").items -}}
+{{-       $labels := .metadata.labels | default dict -}}
+{{-       if and (not .spec.unschedulable) (not (hasKey $labels "node-role.kubernetes.io/control-plane")) (not (hasKey $labels "node-role.kubernetes.io/master")) -}}
+{{-         $nodeCount = add1 $nodeCount -}}
+{{-       end -}}
+{{-     end -}}
+{{-   end -}}
+{{-   if lt $nodeCount 1 -}}{{- $nodeCount = 1 -}}{{- end -}}
+{{-   $replicas = mul $coresPerNode $nodeCount -}}
+{{- end -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name.dcn }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ $replicas }}
+  selector:
+    matchLabels:
+      app: {{ .Values.name.dcn }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name.dcn }}
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.name.dcn }}
+      {{- with .Values.dcn.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.name.dcn }}
+          image: "ghcr.io/oliver-zehentleitner/ubdcc-dcn:{{ .Chart.AppVersion }}"
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: {{ .Values.k8s.verifySsl | quote }}
+          {{- with .Values.dcn.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- else -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -12,9 +82,18 @@ spec:
       labels:
         app: {{ .Values.name.dcn }}
     spec:
+      {{- with .Values.dcn.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.name.dcn }}
           image: "ghcr.io/oliver-zehentleitner/ubdcc-dcn:{{ .Chart.AppVersion }}"
           env:
             - name: UBDCC_K8S_VERIFY_SSL
               value: {{ .Values.k8s.verifySsl | quote }}
+          {{- with .Values.dcn.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+{{- end -}}

--- a/dev/helm/ubdcc/values.yaml
+++ b/dev/helm/ubdcc/values.yaml
@@ -7,6 +7,40 @@ name:
 replicaCount:
   restapi: 3
 
+dcn:
+  # DCNs per CPU core. Each DCN is a single Python process (GIL-bound), so one
+  # DCN per CPU core is the optimal distribution.
+  #   1 (default) -> DaemonSet: exactly 1 DCN pod per node. Auto-scales with the
+  #                  cluster, needs no node lookup / RBAC.
+  #   N > 1        -> Deployment with N pods per node (see nodeCount below).
+  # Set the core count of your DCN nodes at install time, e.g.:
+  #   helm install ... --set dcn.coresPerNode=4
+  coresPerNode: 1
+
+  # Only used when coresPerNode > 1 (Deployment mode).
+  # Number of nodes to spread DCN pods across.
+  # "" (default) auto-detects the count of schedulable worker nodes from the
+  # cluster at install time. This needs permission to list nodes (cluster
+  # scope) for whoever runs `helm install`; control-plane and unschedulable
+  # nodes are skipped. On `helm template`/`--dry-run` the lookup is empty and
+  # it falls back to 1. Set an integer to override, e.g. --set dcn.nodeCount=3
+  nodeCount: ""
+
+  # Total replica count. "" (default) = coresPerNode × nodeCount.
+  # Setting an integer forces Deployment mode and overrides the whole
+  # calculation, e.g. --set dcn.replicas=12
+  replicas: ""
+
+  # Optional: pin DCN pods to specific nodes (e.g. a dedicated DCN node pool).
+  nodeSelector: {}
+
+  # Optional: set requests == limits with integer cpu for Guaranteed QoS,
+  # required for real per-core CPU pinning (needs kubelet cpuManagerPolicy: static).
+  # Example:
+  #   requests: {cpu: 1, memory: 256Mi}
+  #   limits:   {cpu: 1, memory: 256Mi}
+  resources: {}
+
 publicPort:
   restapi: 80
 


### PR DESCRIPTION
## Summary
- The Helm chart's DCN **default is unchanged**: a `DaemonSet` with exactly one DCN pod per node — auto-scales with the cluster, needs no node lookup / RBAC.
- Each DCN is a single GIL-bound Python process, so one DCN per CPU core is the optimal distribution. Setting `dcn.coresPerNode > 1` (or an explicit `dcn.replicas`) switches the DCN to a `Deployment` that spreads pods evenly across nodes (`topologySpreadConstraints`, `maxSkew: 1`).
- Replica precedence: `dcn.replicas` > `coresPerNode × dcn.nodeCount` > `coresPerNode × auto-detected nodes` (schedulable, non-control-plane; falls back to 1 on `helm template`/`--dry-run`).

## New Helm values (`dcn.*`)
| value | default | effect |
|-------|---------|--------|
| `coresPerNode` | `1` | `1` → DaemonSet (1/node); `>1` → Deployment with N/node |
| `nodeCount` | `""` | override node auto-detection (Deployment mode) |
| `replicas` | `""` | force Deployment + override the whole calculation |
| `nodeSelector` | `{}` | pin DCN to a node pool |
| `resources` | `{}` | set requests == limits for Guaranteed QoS / CPU pinning |

## Examples
```bash
helm install ubdcc ubdcc/ubdcc                                  # DaemonSet, 1 DCN/node
helm install ubdcc ubdcc/ubdcc --set dcn.coresPerNode=4         # 4 DCN/node, nodes auto-detected
helm install ubdcc ubdcc/ubdcc --set dcn.coresPerNode=4 \
  --set dcn.nodeCount=3                                          # -> 12 DCN pods
helm install ubdcc ubdcc/ubdcc --set dcn.replicas=12            # fixed total
```

## Notes
- Switching `coresPerNode` across the 1↔>1 boundary on `helm upgrade` changes the resource kind (DaemonSet ↔ Deployment); Helm deletes the old object and creates the new one → brief DCN gap when changing topology.
- Auto-detection needs node-list permission for whoever runs `helm install`.

## Test plan
- [x] `helm lint` clean
- [x] default renders `DaemonSet` (no replicas)
- [x] `coresPerNode=4 nodeCount=3` renders `Deployment` with `replicas: 12`
- [x] `dcn.replicas=7` renders `Deployment` with `replicas: 7`
- [x] `nodeSelector`/`resources` render in both modes
- [ ] auto-detect `lookup` path verified on a live multi-node cluster
