### PR TITLE
Helm chart: RESTAPI on DaemonSet (1/node), optional N pods per node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
   `dcn.replicas` (force Deployment mode + override the whole calculation),
   `dcn.nodeSelector` (pin DCN to a node pool) and `dcn.resources` (set
   requests == limits for Guaranteed QoS / per-core CPU pinning).
+- Helm values `restapi.perNode`, `restapi.nodeCount`, `restapi.replicas`,
+  `restapi.nodeSelector` and `restapi.resources` — symmetric to the `dcn.*`
+  block, for tuning the RESTAPI topology.
+### Changed
+- Helm chart: RESTAPI is now a `DaemonSet` by default (exactly 1 RESTAPI pod
+  per node, auto-scales with the cluster) instead of a hard-coded
+  `StatefulSet` with `replicas: 3` + per-host `podAntiAffinity`. The old
+  layout broke on clusters with < 3 nodes (pods stuck `Pending`) and wasted
+  capacity on clusters with > 3 nodes. Setting `restapi.perNode > 1` (or
+  an explicit `restapi.replicas`) switches RESTAPI to a `Deployment` with
+  `replicas = perNode × nodeCount`, spread evenly via
+  `topologySpreadConstraints`. The `replicaCount.restapi` value is removed.
+- `admin/k8s/ubdcc-restapi.yaml` updated to match (plain `DaemonSet`).
 
 ## 0.9.1
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ API throughput, and automatic state recovery if pods restart.
 
 The system consists of three components:
 - **mgmt** (1x) — manages the cluster state and distributes DepthCaches across nodes
-- **restapi** (1-3x) — REST API gateway, load-balances data requests to DCN processes
+- **restapi** (1 per node, scalable) — REST API gateway, load-balances data requests to DCN processes
 - **dcn** (multiple) — runs the actual DepthCaches via UBLDC
 
 Each DCN runs a single Python process, so **one DCN per CPU core** gives the best performance (Python's GIL limits 
@@ -121,7 +121,7 @@ each process to one core).
 | Setup | Example configuration |
 |-------|----------------------|
 | Local (8-core PC) | 1 mgmt, 1 restapi, 6 DCN processes |
-| Kubernetes (2 servers, 4 cores each) | 1 mgmt, 3 restapi, 4 DCN pods |
+| Kubernetes (2 servers, 4 cores each) | 1 mgmt, 2 restapi (1/node), 4 DCN pods |
 
 When you create DepthCaches (e.g. 200 markets with `desired_quantity=2`), UBDCC distributes them evenly across DCN 
 processes. Each DCN downloads order book snapshots using its own network connection. Replicas are created for 
@@ -532,6 +532,37 @@ helm install ubdcc ubdcc/ubdcc --namespace ubdcc
 #### Choose an alternate public port
 ``` 
 helm install ubdcc ubdcc/ubdcc --set publicPort.restapi=8080
+```
+
+#### Scale RESTAPI per node
+By default the chart deploys the RESTAPI as a `DaemonSet` — **exactly one RESTAPI pod per node**.
+This auto-scales as you add or remove nodes and needs no extra permissions; the cluster `Service`
+load-balances incoming requests across all RESTAPI pods.
+
+To run more than one RESTAPI pod per node (e.g. to absorb heavier client load on a small
+cluster), set:
+
+```
+helm install ubdcc ubdcc/ubdcc --set restapi.perNode=2
+```
+
+With `perNode > 1` the RESTAPI becomes a `Deployment` whose pods are spread evenly across nodes
+(`topologySpreadConstraints`, `maxSkew: 1`). The node count is auto-detected from the cluster at
+install time (only schedulable, non control-plane nodes), so
+`replicas = perNode × nodeCount`. Auto-detection needs permission to list nodes for whoever runs
+`helm install`; on `helm template`/`--dry-run` it falls back to a single node.
+
+Override any level explicitly:
+
+```
+# fix the node count instead of auto-detecting
+helm install ubdcc ubdcc/ubdcc --set restapi.perNode=2 --set restapi.nodeCount=3   # -> 6 RESTAPI pods
+
+# set the total replica count directly (bypasses the calculation)
+helm install ubdcc ubdcc/ubdcc --set restapi.replicas=6
+
+# pin RESTAPI to a dedicated node pool
+helm install ubdcc ubdcc/ubdcc --set restapi.nodeSelector.role=edge
 ```
 
 #### Scale DCN per CPU core

--- a/admin/k8s/ubdcc-restapi.yaml
+++ b/admin/k8s/ubdcc-restapi.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: DaemonSet
 
 metadata:
   name: ubdcc-restapi
@@ -7,8 +7,6 @@ metadata:
   annotations:
     author: oliver-zehentleitner
 spec:
-  serviceName: ubdcc-restapi
-  replicas: 3
   selector:
     matchLabels:
       app: ubdcc-restapi
@@ -19,13 +17,6 @@ spec:
       annotations:
         author: oliver-zehentleitner
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: ubdcc-restapi
-              topologyKey: "kubernetes.io/hostname"
       containers:
         - name: ubdcc-restapi
           image: ghcr.io/oliver-zehentleitner/ubdcc-restapi:0.9.1

--- a/dev/helm/ubdcc/templates/ubdcc-restapi.yaml
+++ b/dev/helm/ubdcc/templates/ubdcc-restapi.yaml
@@ -1,14 +1,45 @@
+{{- /*
+  RESTAPI topology:
+  - Default (perNode <= 1, no explicit replicas): a DaemonSet -> exactly
+    1 RESTAPI pod per node. Auto-scales when nodes are added/removed, needs no
+    node lookup / cluster RBAC.
+  - perNode > 1 (or an explicit restapi.replicas): a Deployment with
+    N pods per node, spread evenly across nodes (topologySpreadConstraints).
+    Replica precedence: restapi.replicas > perNode × restapi.nodeCount >
+    perNode × auto-detected nodes (schedulable, non-control-plane).
+    The lookup is empty on `helm template`/`--dry-run`, so it falls back to a
+    single node there.
+*/ -}}
+{{- $perNode := .Values.restapi.perNode | int -}}
+{{- $useDeployment := or (gt $perNode 1) (ne (toString .Values.restapi.replicas) "") -}}
+{{- if $useDeployment -}}
+{{- $replicas := 0 -}}
+{{- if .Values.restapi.replicas -}}
+{{-   $replicas = .Values.restapi.replicas | int -}}
+{{- else -}}
+{{-   $nodeCount := 0 -}}
+{{-   if .Values.restapi.nodeCount -}}
+{{-     $nodeCount = .Values.restapi.nodeCount | int -}}
+{{-   else -}}
+{{-     range (lookup "v1" "Node" "" "").items -}}
+{{-       $labels := .metadata.labels | default dict -}}
+{{-       if and (not .spec.unschedulable) (not (hasKey $labels "node-role.kubernetes.io/control-plane")) (not (hasKey $labels "node-role.kubernetes.io/master")) -}}
+{{-         $nodeCount = add1 $nodeCount -}}
+{{-       end -}}
+{{-     end -}}
+{{-   end -}}
+{{-   if lt $nodeCount 1 -}}{{- $nodeCount = 1 -}}{{- end -}}
+{{-   $replicas = mul $perNode $nodeCount -}}
+{{- end -}}
 apiVersion: apps/v1
-kind: StatefulSet
-
+kind: Deployment
 metadata:
   name: {{ .Values.name.restapi }}
   namespace: {{ .Release.Namespace }}
   annotations:
     author: oliver-zehentleitner
 spec:
-  serviceName: {{ .Values.name.restapi }}
-  replicas: {{ .Values.replicaCount.restapi }}
+  replicas: {{ $replicas }}
   selector:
     matchLabels:
       app: {{ .Values.name.restapi }}
@@ -19,13 +50,17 @@ spec:
       annotations:
         author: oliver-zehentleitner
     spec:
-      affinity:
-        podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - labelSelector:
-                matchLabels:
-                  app: {{ .Values.name.restapi }}
-              topologyKey: "kubernetes.io/hostname"
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: {{ .Values.name.restapi }}
+      {{- with .Values.restapi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Values.name.restapi }}
           image: "ghcr.io/oliver-zehentleitner/ubdcc-restapi:{{ .Chart.AppVersion }}"
@@ -36,9 +71,13 @@ spec:
             - name: UBDCC_K8S_VERIFY_SSL
               value: {{ .Values.k8s.verifySsl | quote }}
           resources:
+          {{- if .Values.restapi.resources }}
+            {{- toYaml .Values.restapi.resources | nindent 12 }}
+          {{- else }}
             requests:
               cpu: "250m"
               memory: "512Mi"
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /test
@@ -49,3 +88,54 @@ spec:
               path: /test
               port: rest-private
             initialDelaySeconds: 40
+{{- else -}}
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.name.restapi }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    author: oliver-zehentleitner
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Values.name.restapi }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Values.name.restapi }}
+      annotations:
+        author: oliver-zehentleitner
+    spec:
+      {{- with .Values.restapi.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Values.name.restapi }}
+          image: "ghcr.io/oliver-zehentleitner/ubdcc-restapi:{{ .Chart.AppVersion }}"
+          ports:
+            - name: rest-private
+              containerPort: 8080
+          env:
+            - name: UBDCC_K8S_VERIFY_SSL
+              value: {{ .Values.k8s.verifySsl | quote }}
+          resources:
+          {{- if .Values.restapi.resources }}
+            {{- toYaml .Values.restapi.resources | nindent 12 }}
+          {{- else }}
+            requests:
+              cpu: "250m"
+              memory: "512Mi"
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /test
+              port: rest-private
+            initialDelaySeconds: 40
+          livenessProbe:
+            httpGet:
+              path: /test
+              port: rest-private
+            initialDelaySeconds: 40
+{{- end -}}

--- a/dev/helm/ubdcc/values.yaml
+++ b/dev/helm/ubdcc/values.yaml
@@ -4,9 +4,6 @@ name:
   mgmt: ubdcc-mgmt
   restapi: ubdcc-restapi
 
-replicaCount:
-  restapi: 3
-
 dcn:
   # DCNs per CPU core. Each DCN is a single Python process (GIL-bound), so one
   # DCN per CPU core is the optimal distribution.
@@ -39,6 +36,35 @@ dcn:
   # Example:
   #   requests: {cpu: 1, memory: 256Mi}
   #   limits:   {cpu: 1, memory: 256Mi}
+  resources: {}
+
+restapi:
+  # RESTAPI pods per node.
+  #   1 (default) -> DaemonSet: exactly 1 RESTAPI pod per node. Auto-scales with
+  #                  the cluster, needs no node lookup / RBAC.
+  #   N > 1        -> Deployment with N pods per node (see nodeCount below).
+  # Override at install time, e.g.:
+  #   helm install ... --set restapi.perNode=2
+  perNode: 1
+
+  # Only used when perNode > 1 (Deployment mode).
+  # Number of nodes to spread RESTAPI pods across.
+  # "" (default) auto-detects the count of schedulable worker nodes from the
+  # cluster at install time. This needs permission to list nodes (cluster
+  # scope) for whoever runs `helm install`; control-plane and unschedulable
+  # nodes are skipped. On `helm template`/`--dry-run` the lookup is empty and
+  # it falls back to 1. Set an integer to override, e.g. --set restapi.nodeCount=3
+  nodeCount: ""
+
+  # Total replica count. "" (default) = perNode × nodeCount.
+  # Setting an integer forces Deployment mode and overrides the whole
+  # calculation, e.g. --set restapi.replicas=12
+  replicas: ""
+
+  # Optional: pin RESTAPI pods to specific nodes.
+  nodeSelector: {}
+
+  # Optional: container resource requests / limits.
   resources: {}
 
 publicPort:

--- a/llms.txt
+++ b/llms.txt
@@ -85,9 +85,9 @@ Base URL: `http://127.0.0.1:{port}/`
 
 ## Architecture
 
-- **Management (mgmt)**: orchestrates pods, assigns depth caches to nodes
-- **REST API**: HTTP interface for external access
-- **DCN (DepthCache Node)**: runs actual UBLDC instances, managed by mgmt
+- **Management (mgmt)**: orchestrates pods, assigns depth caches to nodes (singleton)
+- **REST API (restapi)**: HTTP interface for external access; Helm chart deploys it as a `DaemonSet` (1 pod per node) by default, `restapi.perNode=N` switches to a `Deployment` with `N × nodes` pods
+- **DCN (DepthCache Node)**: runs actual UBLDC instances, managed by mgmt; Helm chart deploys it as a `DaemonSet` by default, `dcn.coresPerNode=N` switches to a `Deployment` with `N × nodes` pods (one DCN per CPU core is optimal, GIL-bound)
 
 Runs as processes on a single machine or as pods on Kubernetes.
 


### PR DESCRIPTION
## What

Switches the RESTAPI in the Helm chart from a hard-coded `StatefulSet` with
`replicas: 3` + per-host `podAntiAffinity` to the same topology pattern the
DCN already uses:

- **Default:** `DaemonSet` — exactly 1 RESTAPI pod per node, auto-scales with
  the cluster, no node lookup / RBAC needed.
- **`restapi.perNode > 1`:** `Deployment` with
  `replicas = perNode × nodeCount`, spread evenly via
  `topologySpreadConstraints` (`maxSkew: 1`). `nodeCount` is auto-detected
  via `lookup` (schedulable, non-control-plane), overridable via
  `--set restapi.nodeCount=N`.
- **`restapi.replicas=N`:** hard override, forces Deployment mode.

## Why

The old layout was hard-coded for a 3-node cluster:
- Clusters with **< 3 nodes** → pods stuck `Pending`
  (`requiredDuringSchedulingIgnoredDuringExecution` +
  `topologyKey: hostname`).
- Clusters with **> 3 nodes** → remaining nodes unused.
- `StatefulSet` brought no benefit — RESTAPI is effectively stateless
  (proxies to mgmt, live-fetches from DCNs).

With `DaemonSet` as the default, RESTAPI mirrors DCN behavior and scales
with the cluster size without any tuning.

## Changes

- `dev/helm/ubdcc/templates/ubdcc-restapi.yaml` — DaemonSet/Deployment
  branch analogous to `ubdcc-dcn.yaml`. `StatefulSet`, `serviceName`,
  `podAntiAffinity` removed.
- `dev/helm/ubdcc/values.yaml` — new `restapi:` block with `perNode`,
  `nodeCount`, `replicas`, `nodeSelector`, `resources`. Old
  `replicaCount.restapi: 3` removed.
- `admin/k8s/ubdcc-restapi.yaml` — plain manifest switched to `DaemonSet`
  to match the new default.
- Service `ubdcc-restapi` unchanged (ClusterIP, selects `app: ubdcc-restapi`
  — works for both DaemonSet and Deployment mode).
- `README.md` — architecture line (`1-3x` → `1 per node, scalable`),
  example table, new "Scale RESTAPI per node" section before the DCN
  section.
- `llms.txt` — architecture bullets updated (RESTAPI + DCN Helm topology).
- `CHANGELOG.md` — entry under `0.9.1.dev`.

## Smoke tests (`helm template`)

| Invocation                                                | Kind         | replicas |
|-----------------------------------------------------------|--------------|----------|
| default                                                   | `DaemonSet`  | n/a      |
| `--set restapi.perNode=2 --set restapi.nodeCount=3`       | `Deployment` | 6        |
| `--set restapi.perNode=2` (fallback, no lookup access)    | `Deployment` | 2        |
| `--set restapi.replicas=5`                                | `Deployment` | 5        |

`helm lint` clean.

## Breaking?

No code path changes, RESTAPI stays API-compatible. The effective pod count
per cluster does change:
- 1-node cluster: 1 instead of 0 (was: Pending).
- 2-node cluster: 2 instead of 0–2 (was: 1 Pending).
- 3-node cluster: 3 instead of 3 — no change.
- N-node cluster (N>3): N instead of 3 — more pods, better load distribution.

To keep the old behavior: `--set restapi.replicas=3`.