### PR TITLE
Add Keep the Why setup: context/, config block, badge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ venv.bak/
 # mypy
 .mypy_cache/
 CLAUDE.md
+
+AGENTS.local.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,10 @@
 > **End-user cheatsheet for AI-assisted consumption:** [`llms.txt`](llms.txt) — use that one if you're writing code *against* this cluster.
 > **This file** is for AI agents working *on* this repo itself.
 
+## Why things are the way they are
+
+See [`context/index.md`](context/index.md) before making non-trivial changes — it points to the reasoning behind design decisions, rejected alternatives, and constraints that aren't visible in the code. If `AGENTS.local.md` exists in this repo, that's personal/local notes, not relevant to anyone else.
+
 ## Planning & Backlog
 
 Open development tasks and decisions are tracked in **[TASKS.md](TASKS.md)**.
@@ -116,7 +120,7 @@ Interactive shell commands: `status`, `add-dcn [count]`, `remove-dcn <count|name
 - **Setup:** `admin/k8s/setup/` (namespace, RBAC)
 - **Helm chart:** `dev/helm/ubdcc/`
 
-**Note:** Helm chart and K8s YAMLs still reference the old OVH registry — migration to ghcr.io pending (see TASKS.md).
+Helm chart and K8s YAMLs reference `ghcr.io` — the OVH-registry migration (tracked in `TASKS.md`) has landed; no OVH references remain in `admin/k8s/` or `dev/helm/ubdcc/`.
 
 ---
 
@@ -150,8 +154,11 @@ CI workflows in `.github/workflows/`:
 - `build_wheels_ubdcc.yml` — pure Python wheel + sdist
 - `docker_build.yml` — Docker images to ghcr.io
 - `gh_release.yml` — GitHub Release creation
+- `helm_release.yml` — packages and publishes the Helm chart to `docs/helm/`
 - `unit-tests.yml` — Python 3.9 + 3.14 pytest with Codecov
 - `codeql.yml` — static analysis
+
+No conda-forge distribution — PyPI + ghcr.io Docker only, by design: see [`context/history.md`](context/history.md).
 
 ---
 
@@ -170,3 +177,8 @@ Placeholder tests only — see TASKS.md.
 - Port retry fallback: if the REST server can't bind on the first attempt (race condition), it increments and tries again
 - `SO_REUSEADDR` is set on the port check to handle TIME_WAIT after a restart
 - `os._exit(0)` is scheduled 0.5s after the `/shutdown` response to ensure the process terminates even if the main loop is stuck in `asyncio.sleep`
+
+<!-- keep-the-why:config -->
+- context: `context/`
+- init: complete
+<!-- /keep-the-why:config -->

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 [![Github](https://img.shields.io/badge/source-github-cbc2c8)](https://github.com/oliver-zehentleitner/unicorn-binance-depth-cache-cluster)
 [![Telegram](https://img.shields.io/badge/community-telegram-41ab8c)](https://t.me/unicorndevs)
 [![Reddit](https://img.shields.io/badge/community-reddit-41ab8c)](https://www.reddit.com/r/UNICORNBinanceSuite)
+[![Keep the Why](https://keepthewhy.com/assets/badge.svg)](https://keepthewhy.com)
 
 [![UBS-Banner](https://raw.githubusercontent.com/oliver-zehentleitner/unicorn-binance-suite/master/images/logo/UBS-Banner-Readme.png)](https://blog.technopathy.club/page/unicorn-binance-suite)
 

--- a/context/README.md
+++ b/context/README.md
@@ -1,0 +1,10 @@
+<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why" width="200">
+
+# Context
+
+Why this project is built the way it is — architecture decisions,
+rejected alternatives, workarounds, and reasoning the code alone
+can't show. Captured and kept current by the [Keep the
+Why](https://keepthewhy.com) agent skill.
+
+Not usage docs — see `docs/` for that. Start with `index.md`.

--- a/context/fail-loud.md
+++ b/context/fail-loud.md
@@ -1,0 +1,12 @@
+# Fail loud: error #6000 instead of stale data
+
+## Out-of-sync DepthCaches return an explicit error, never silently stale data
+
+**Status:** active, stable since early in the project's life
+**Confirmed** (code path in `packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py`; present since commit `938eed7`, Oct 2024 — i.e. from the LUCIT era already, not a recent addition)
+
+When a `DepthCacheNode` catches UBLDC's `DepthCacheOutOfSync`, `get_asks`/`get_bids` return `error_id="#6000"` instead of the last-known (now potentially stale) order-book levels.
+
+**Reason:** stated explicitly in the README (commit `8490df2`): *"The cluster either serves consistent data or fails loudly; it never silently accumulates stale levels."* This is the suite-wide fail-loud philosophy applied to the cluster's public API specifically — a caller getting `#6000` can decide to wait, retry, or reduce confidence, instead of unknowingly trading on an order book that looks fine but no longer reflects the exchange.
+
+**Rejected alternative (implicit):** serving the last-known state while a resync is in progress, to avoid returning errors to callers. Rejected by the same reasoning as the rest of the suite's fail-loud convention — a plausible-looking but wrong order book is worse than a visible gap.

--- a/context/history.md
+++ b/context/history.md
@@ -1,0 +1,28 @@
+# History
+
+## LUCIT-Systems-and-Development origin
+
+**Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
+**Confirmed** (commit `e5aecb1` "Remove LUCIT licensing and rebrand to MIT open source"; earliest commit `32bdf57` "INIT", 2024-09-04, already within the LUCIT era)
+
+Same lineage as the rest of the suite — this module was not born newer/independent of the LUCIT history despite being one of the more recently active repos. Package directories were renamed `lucit-ubdcc-* → ubdcc-*` as part of the rebrand.
+
+**Reason:** LUCIT is no longer part of how this project is licensed, distributed, or supported.
+
+## OVH → ghcr.io registry migration
+
+**Status:** superseded — migration complete
+**Confirmed** (commits `0421504` "K8s YAMLs: migrate to ghcr.io with version tag instead of SHA digest", `587c750` "Helm: update image registry URLs from OVH to ghcr.io")
+
+Docker images now live on `ghcr.io/oliver-zehentleitner/ubdcc-*`. `admin/k8s/*.yaml` and `dev/helm/ubdcc/` no longer reference the old OVH container registry or its SHA256 digests.
+
+**Note found while writing this:** `TASKS.md` still had this listed as an open backlog item ("Update Helm chart and K8s YAMLs to ghcr.io") and `AGENTS.md` repeated the same stale claim — both predate the actual migration commits above. Fixed the `AGENTS.md` claim as part of this pass; the `TASKS.md` checkbox is left for Oliver to close since it's his backlog, not `context/`'s to groom.
+
+## No conda-forge distribution — by design, not an oversight
+
+**Status:** active
+**Confirmed** (commit `ea5fd2c`: "UBDCC is intentionally not distributed via conda-forge (PyPI + ghcr.io Docker only). The badge pointed at a build_conda.yml workflow that doesn't exist and never will.")
+
+Unlike its sibling suite modules, UBDCC has no conda-forge feedstock and never did — distribution is PyPI (wheels per sub-package) plus Docker images on `ghcr.io`.
+
+**Reason:** stated directly in the commit removing a leftover Anaconda badge — this was a deliberate scope decision for this module, not a migration-in-progress or an oversight like the LUCIT-era conda cleanups in the rest of the suite.

--- a/context/index.md
+++ b/context/index.md
@@ -1,0 +1,4 @@
+# Context index
+
+- [fail-loud.md](fail-loud.md) — why the cluster returns error `#6000` instead of stale data when a node is out of sync
+- [history.md](history.md) — the LUCIT-Systems-and-Development origin, the OVH→ghcr.io registry migration, and why there's no conda-forge distribution


### PR DESCRIPTION
## Summary
- Adopts the Keep the Why convention: context/fail-loud.md (why out-of-sync DepthCaches return error #6000 instead of stale data), context/history.md (LUCIT origin, the completed OVH->ghcr.io registry migration, why there's deliberately no conda-forge distribution)
- AGENTS.md trimmed to pointers; fixed a stale claim (OVH->ghcr.io migration is done, not pending) and added the missing helm_release.yml to the CI/CD workflow list
- README.md: Keep the Why badge
- .gitignore: AGENTS.local.md (not committed)

## Test plan
- [ ] Read through context/*.md for accuracy against actual history
- [ ] Close the OVH->ghcr.io item in TASKS.md — it's already done, left that edit for you since it's your backlog