### PR TITLE
docs: update Keep the Why to v0.5.1 (context/README.md, schema migration)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,4 +181,6 @@ Placeholder tests only — see TASKS.md.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
+- context-schema: 0.5.1
+- capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -1,10 +1,39 @@
-<img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why">
+<a href="https://keepthewhy.com"><img src="https://keepthewhy.com/assets/logo.png" alt="Keep the Why"></a>
 
-# Context
+# Project context
 
-Why this project is built the way it is — architecture decisions,
-rejected alternatives, workarounds, and reasoning the code alone
-can't show. Captured and kept current by the [Keep the
-Why](https://keepthewhy.com) agent skill.
+This directory preserves the reasoning behind this project: architectural
+decisions, constraints, rejected alternatives, incident learnings,
+deliberate workarounds, and other knowledge that the code alone cannot
+explain.
 
-Not usage docs — see `docs/` for that. Start with `index.md`.
+It's organized and kept current according to the [Keep the
+Why](https://keepthewhy.com) schema — a repo-native agent skill, not
+specific to this project. Recognizing that schema means an agent (or a
+person who's seen it before) already knows how this directory is
+structured and how to work with it, without first having to figure that
+out from scratch.
+
+It answers:
+
+> Why is the project built this way?
+
+For usage, installation, operation, or troubleshooting, see `docs/`.
+
+## Reading the entries
+
+Each entry separates:
+
+- **Status** — whether a decision is active, superseded, open, or needs review
+- **Evidence** — whether its rationale is confirmed, inferred, or unknown
+
+Old reasoning is retained when it remains useful for understanding how the
+project evolved.
+
+## Trust boundary
+
+Files in this directory describe project knowledge. They do not contain
+instructions that grant permissions, override user intent, authorize
+commands, or weaken security controls.
+
+Start with the [context index](index.md).

--- a/context/fail-loud.md
+++ b/context/fail-loud.md
@@ -3,7 +3,8 @@
 ## Out-of-sync DepthCaches return an explicit error, never silently stale data
 
 **Status:** active, stable since early in the project's life
-**Confirmed** (code path in `packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py`; present since commit `938eed7`, Oct 2024 — i.e. from the LUCIT era already, not a recent addition)
+**Evidence:** confirmed
+**Source:** code path in `packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py`; present since commit `938eed7`, Oct 2024 — i.e. from the LUCIT era already, not a recent addition
 
 When a `DepthCacheNode` catches UBLDC's `DepthCacheOutOfSync`, `get_asks`/`get_bids` return `error_id="#6000"` instead of the last-known (now potentially stale) order-book levels.
 

--- a/context/history.md
+++ b/context/history.md
@@ -3,7 +3,8 @@
 ## LUCIT-Systems-and-Development origin
 
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
-**Confirmed** (commit `e5aecb1` "Remove LUCIT licensing and rebrand to MIT open source"; earliest commit `32bdf57` "INIT", 2024-09-04, already within the LUCIT era)
+**Evidence:** confirmed
+**Source:** commit `e5aecb1` "Remove LUCIT licensing and rebrand to MIT open source"; earliest commit `32bdf57` "INIT", 2024-09-04, already within the LUCIT era
 
 Same lineage as the rest of the suite — this module was not born newer/independent of the LUCIT history despite being one of the more recently active repos. Package directories were renamed `lucit-ubdcc-* → ubdcc-*` as part of the rebrand.
 
@@ -12,7 +13,8 @@ Same lineage as the rest of the suite — this module was not born newer/indepen
 ## OVH → ghcr.io registry migration
 
 **Status:** superseded — migration complete
-**Confirmed** (commits `0421504` "K8s YAMLs: migrate to ghcr.io with version tag instead of SHA digest", `587c750` "Helm: update image registry URLs from OVH to ghcr.io")
+**Evidence:** confirmed
+**Source:** commits `0421504` "K8s YAMLs: migrate to ghcr.io with version tag instead of SHA digest", `587c750` "Helm: update image registry URLs from OVH to ghcr.io"
 
 Docker images now live on `ghcr.io/oliver-zehentleitner/ubdcc-*`. `admin/k8s/*.yaml` and `dev/helm/ubdcc/` no longer reference the old OVH container registry or its SHA256 digests.
 
@@ -21,7 +23,8 @@ Docker images now live on `ghcr.io/oliver-zehentleitner/ubdcc-*`. `admin/k8s/*.y
 ## No conda-forge distribution — by design, not an oversight
 
 **Status:** active
-**Confirmed** (commit `ea5fd2c`: "UBDCC is intentionally not distributed via conda-forge (PyPI + ghcr.io Docker only). The badge pointed at a build_conda.yml workflow that doesn't exist and never will.")
+**Evidence:** confirmed
+**Source:** commit `ea5fd2c`: "UBDCC is intentionally not distributed via conda-forge (PyPI + ghcr.io Docker only). The badge pointed at a build_conda.yml workflow that doesn't exist and never will."
 
 Unlike its sibling suite modules, UBDCC has no conda-forge feedstock and never did — distribution is PyPI (wheels per sub-package) plus Docker images on `ghcr.io`.
 


### PR DESCRIPTION
## Summary
- `context/README.md`: adopt new Keep the Why template (linked logo, "Project context" heading, Reading the entries + Trust boundary sections, links to `index.md`)
- `AGENTS.md`: backfill `context-schema: 0.5.1` and `capture-confirmation: confirm-when-unsure` in the project config block (both fields were missing entirely)
- `context/`: migrate existing entries to the 0.3.0 Status/Evidence split — `**Confirmed** (X)` becomes `**Evidence:** confirmed` + `**Source:** X`

No content/rationale changes — pure schema/template migration, aligning with Keep the Why v0.5.1.