### PR TITLE
chore(ktw): bump context-schema to 0.8.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,6 @@ Placeholder tests only — see TASKS.md.
 <!-- keep-the-why:config -->
 - context: `context/`
 - init: complete
-- context-schema: 0.5.1
+- context-schema: 0.8.0
 - capture-confirmation: confirm-when-unsure
 <!-- /keep-the-why:config -->

--- a/context/README.md
+++ b/context/README.md
@@ -24,6 +24,7 @@ For usage, installation, operation, or troubleshooting, see `docs/`.
 
 Each entry separates:
 
+- **Type** — what kind of thing it is: decision, workaround, incident, or constraint (or undefined, with a reason, if none fit)
 - **Status** — whether a decision is active, superseded, open, or needs review
 - **Evidence** — whether its rationale is confirmed, inferred, or unknown
 

--- a/context/fail-loud.md
+++ b/context/fail-loud.md
@@ -2,6 +2,7 @@
 
 ## Out-of-sync DepthCaches return an explicit error, never silently stale data
 
+**Type:** decision
 **Status:** active, stable since early in the project's life
 **Evidence:** confirmed
 **Source:** code path in `packages/ubdcc-dcn/ubdcc_dcn/RestEndpoints.py`; present since commit `938eed7`, Oct 2024 — i.e. from the LUCIT era already, not a recent addition

--- a/context/history.md
+++ b/context/history.md
@@ -2,6 +2,7 @@
 
 ## LUCIT-Systems-and-Development origin
 
+**Type:** decision
 **Status:** superseded — repo now lives under `oliver-zehentleitner`, MIT-licensed
 **Evidence:** confirmed
 **Source:** commit `e5aecb1` "Remove LUCIT licensing and rebrand to MIT open source"; earliest commit `32bdf57` "INIT", 2024-09-04, already within the LUCIT era
@@ -12,6 +13,7 @@ Same lineage as the rest of the suite — this module was not born newer/indepen
 
 ## OVH → ghcr.io registry migration
 
+**Type:** decision
 **Status:** superseded — migration complete
 **Evidence:** confirmed
 **Source:** commits `0421504` "K8s YAMLs: migrate to ghcr.io with version tag instead of SHA digest", `587c750` "Helm: update image registry URLs from OVH to ghcr.io"
@@ -22,6 +24,7 @@ Docker images now live on `ghcr.io/oliver-zehentleitner/ubdcc-*`. `admin/k8s/*.y
 
 ## No conda-forge distribution — by design, not an oversight
 
+**Type:** decision
 **Status:** active
 **Evidence:** confirmed
 **Source:** commit `ea5fd2c`: "UBDCC is intentionally not distributed via conda-forge (PyPI + ghcr.io Docker only). The badge pointed at a build_conda.yml workflow that doesn't exist and never will."


### PR DESCRIPTION
Migrates the project's keep-the-why context-schema from its previous value to 0.8.0.

- Bumps `context-schema` in AGENTS.md.
- Adds the Type field line to `context/README.md`'s "Reading the entries" section (0.7.0/0.8.0 migration step).

Individual context/ entries are not backfilled in bulk — per the skill's migration guidance, an entry picks up a Type value the next time it's touched anyway, not as a dedicated pass.